### PR TITLE
Added redstone category aliases (first pass)

### DIFF
--- a/redstone.sk
+++ b/redstone.sk
@@ -1,118 +1,118 @@
 power sources:
-    redstone block¦s = minecraft:redstone_block
-    redstone [dust] block¦s = minecraft:redstone_wire
-    [any] redstone [dust] item¦s = minecraft:redstone
-    redstone [dust] = redstone block, redstone item
-    
-    lit redstone torch¦es = minecraft:redstone_torch
-    unlit redstone torch¦es = minecraft:unlit_redstone_torch
-    [any] redstone torch¦es = lit redstone torch, unlit redstone torch
-    
-    [redstone] lever¦s = minecraft:lever
-    stone pressure plate¦s = minecraft:stone_pressure_plate
-    (gold|light[ ][weight[ed]]) pressure plate¦s = minecraft:light_weighted_pressure_plate
-    (iron|heavy[ ][weight[ed]]) pressure plate¦s = minecraft:heavy_weighted_pressure_plate
-    (normal|uninverted) daylight (detector|sensor)¦s = minecraft:daylight_detector
-    [inverted] daylight (detector|sensor) [inverted]¦s = minecraft:inverted_daylight_detector
-    [any] daylight (detector|sensor)¦s = daylight detector, inverted daylight detector
-    stone button¦s = minecraft:stone_button
-    tripwire hook¦s = minecraft:tripwire_hook
-    trapped chest¦s = minecraft:trapped_chest
+	redstone block¦s = minecraft:redstone_block
+	redstone [dust] block¦s = minecraft:redstone_wire
+	[any] redstone [dust] item¦s = minecraft:redstone
+	redstone [dust] = redstone block, redstone item
+
+	lit redstone torch¦es = minecraft:redstone_torch
+	unlit redstone torch¦es = minecraft:unlit_redstone_torch
+	[any] redstone torch¦es = lit redstone torch, unlit redstone torch
+
+	[redstone] lever¦s = minecraft:lever
+	stone pressure plate¦s = minecraft:stone_pressure_plate
+	(gold|light[ ][weight[ed]]) pressure plate¦s = minecraft:light_weighted_pressure_plate
+	(iron|heavy[ ][weight[ed]]) pressure plate¦s = minecraft:heavy_weighted_pressure_plate
+	(normal|uninverted) daylight (detector|sensor)¦s = minecraft:daylight_detector
+	[inverted] daylight (detector|sensor) [inverted]¦s = minecraft:inverted_daylight_detector
+	[any] daylight (detector|sensor)¦s = daylight detector, inverted daylight detector
+	stone button¦s = minecraft:stone_button
+	tripwire hook¦s = minecraft:tripwire_hook
+	trapped chest¦s = minecraft:trapped_chest
 
 activatables:
-    dispenser¦s = minecraft:dispenser
-    note block¦s = minecraft:note_block
-    dropper¦s = minecraft:dropper
-    tnt¦s = minecraft:tnt
-    
-    lit [redstone] lamp¦s = minecraft:lit_redstone_lamp
-    unlit [redstone] lamp¦s = minecraft:redstone_lamp
-    [any] redstone lamp¦s = lit redstone lamp, unlit redstone lamp
-    
-    normal piston¦s = minecraft:piston
-    sticky piston¦s = minecraft:sticky_piston
-    piston head¦s = minecraft:piston_head
-    (block 36|block moved by piston|moving block¦s) = minecraft:piston_extension
+	dispenser¦s = minecraft:dispenser
+	note block¦s = minecraft:note_block
+	dropper¦s = minecraft:dropper
+	tnt¦s = minecraft:tnt
+	
+	lit [redstone] lamp¦s = minecraft:lit_redstone_lamp
+	unlit [redstone] lamp¦s = minecraft:redstone_lamp
+	[any] redstone lamp¦s = lit redstone lamp, unlit redstone lamp
+	
+	normal piston¦s = minecraft:piston
+	sticky piston¦s = minecraft:sticky_piston
+	piston head¦s = minecraft:piston_head
+	(block 36|block moved by piston|moving block¦s) = minecraft:piston_extension
 
-    iron trapdoor¦s = minecraft:iron_trapdoor
-    
-    (spruce|fir|redwood|pine) [wood[en]] [fence] gate¦s = minecraft:spruce_fence_gate
-    birch [wood[en]] [fence] gate¦s = minecraft:birch_fence_gate
-    jungle [wood[en]] [fence] gate¦s = minecraft:jungle_fence_gate
-    acacia [wood[en]] [fence] gate¦s = minecraft:acacia_fence_gate
-    dark oak [wood[en]] [fence] gate¦s = minecraft:dark_oak_fence_gate
-    
-    iron door¦s = minecraft:iron_door
-    (spruce|fir|redwood|pine) [wood[en]] door¦s = minecraft:spruce_door
-    birch [wood[en]] door¦s = minecraft:birch_door
-    jungle [wood[en]] door¦s = minecraft:jungle_door
-    acacia [wood[en]] door¦s = minecraft:acacia_door
-    dark oak [wood[en]] door¦s = minecraft:dark_oak_door
+	iron trapdoor¦s = minecraft:iron_trapdoor
+	
+	(spruce|fir|redwood|pine) [wood[en]] [fence] gate¦s = minecraft:spruce_fence_gate
+	birch [wood[en]] [fence] gate¦s = minecraft:birch_fence_gate
+	jungle [wood[en]] [fence] gate¦s = minecraft:jungle_fence_gate
+	acacia [wood[en]] [fence] gate¦s = minecraft:acacia_fence_gate
+	dark oak [wood[en]] [fence] gate¦s = minecraft:dark_oak_fence_gate
+	
+	iron door¦s = minecraft:iron_door
+	(spruce|fir|redwood|pine) [wood[en]] door¦s = minecraft:spruce_door
+	birch [wood[en]] door¦s = minecraft:birch_door
+	jungle [wood[en]] door¦s = minecraft:jungle_door
+	acacia [wood[en]] door¦s = minecraft:acacia_door
+	dark oak [wood[en]] door¦s = minecraft:dark_oak_door
 
 legacy wood activatables:
-    minecraft versions = 1.12 or older
-    wood[en] button¦s = minecraft:wooden_button
-    [any] button = stone button, wood button
+	minecraft versions = 1.12 or older
+	wood[en] button¦s = minecraft:wooden_button
+	[any] button = stone button, wood button
 
-    [oak] wood[en] pressure plate¦s = minecraft:wooden_pressure_plate
-    [any] pressure plate¦s = stone pressure plate, wood pressure plate, gold pressure plate, iron pressure plate
-    
-    [oak] wood[en] trapdoor¦s = minecraft:trapdoor
-    [any] trapdoor¦s = wood trapdoor, iron trapdoor
-    
-    (oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:fence_gate
-    [any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
-    
-    (oak|regular|normal) [wood[en]] door¦s = minecraft:wooden_door
-    [any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
-    [any] door¦s = iron door, any wood door
+	[oak] wood[en] pressure plate¦s = minecraft:wooden_pressure_plate
+	[any] pressure plate¦s = stone pressure plate, wood pressure plate, gold pressure plate, iron pressure plate
+	
+	[oak] wood[en] trapdoor¦s = minecraft:trapdoor
+	[any] trapdoor¦s = wood trapdoor, iron trapdoor
+	
+	(oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:fence_gate
+	[any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
+	
+	(oak|regular|normal) [wood[en]] door¦s = minecraft:wooden_door
+	[any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
+	[any] door¦s = iron door, any wood door
 
 current wood activatables:
-    minecraft versions = 1.13 or newer
-    (oak|regular|normal) [wood[en]] button¦s = minecraft:oak_button
-    (spruce|fir|redwood|pine) [wood[en]] button¦s = minecraft:spruce_button
-    birch [wood[en]] button¦s = minecraft:birch_button
-    jungle [wood[en]] button¦s = minecraft:jungle_button
-    acacia [wood[en]] button¦s = minecraft:acacia_button
-    dark oak [wood[en]] button¦s = minecraft:dark_oak_button
-    [any] button¦s = stone button, oak button, spruce button, birch button, jungle button, acacia button, dark oak button
+	minecraft versions = 1.13 or newer
+	(oak|regular|normal) [wood[en]] button¦s = minecraft:oak_button
+	(spruce|fir|redwood|pine) [wood[en]] button¦s = minecraft:spruce_button
+	birch [wood[en]] button¦s = minecraft:birch_button
+	jungle [wood[en]] button¦s = minecraft:jungle_button
+	acacia [wood[en]] button¦s = minecraft:acacia_button
+	dark oak [wood[en]] button¦s = minecraft:dark_oak_button
+	[any] button¦s = stone button, oak button, spruce button, birch button, jungle button, acacia button, dark oak button
 
-    (oak|regular|normal) [wood[en]] pressure plate¦s = minecraft:oak_pressure_plate
-    (spruce|fir|redwood|pine) [wood[en]] pressure plate¦s = minecraft:spruce_pressure_plate
-    birch [wood[en]] pressure plate¦s = minecraft:birch_pressure_plate
-    jungle [wood[en]] pressure plate¦s = minecraft:jungle_pressure_plate
-    acacia [wood[en]] pressure plate¦s = minecraft:acacia_pressure_plate
-    dark oak [wood[en]] pressure plate¦s = minecraft:dark_oak_pressure_plate
-    [any] pressure plate¦s = stone pressure plate, oak pressure plate, spruce pressure plate, birch pressure plate, jungle pressure plate, acacia pressure plate, dark oak pressure plate, gold pressure plate, iron pressure plate
-    
-    (oak|regular|normal) [wood[en]] trapdoor¦s = minecraft:oak_trapdoor
-    (spruce|fir|redwood|pine) [wood[en]] trapdoor¦s = minecraft:spruce_trapdoor
-    birch [wood[en]] trapdoor¦s = minecraft:birch_trapdoor
-    jungle [wood[en]] trapdoor¦s = minecraft:jungle_trapdoor
-    acacia [wood[en]] trapdoor¦s = minecraft:acacia_trapdoor
-    dark oak [wood[en]] trapdoor¦s = minecraft:dark_oak_trapdoor
-    [any] trapdoor¦s = iron trapdoor, oak trapdoor, spruce trapdoor, birch trapdoor, jungle trapdoor, acacia trapdoor, dark oak trapdoor
-    
-    (oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:oak_fence_gate
-    [any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
-    
-    (oak|regular|normal) [wood[en]] door¦s = minecraft:oak_door
-    [any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
-    [any] door¦s = iron door, any wood door
+	(oak|regular|normal) [wood[en]] pressure plate¦s = minecraft:oak_pressure_plate
+	(spruce|fir|redwood|pine) [wood[en]] pressure plate¦s = minecraft:spruce_pressure_plate
+	birch [wood[en]] pressure plate¦s = minecraft:birch_pressure_plate
+	jungle [wood[en]] pressure plate¦s = minecraft:jungle_pressure_plate
+	acacia [wood[en]] pressure plate¦s = minecraft:acacia_pressure_plate
+	dark oak [wood[en]] pressure plate¦s = minecraft:dark_oak_pressure_plate
+	[any] pressure plate¦s = stone pressure plate, oak pressure plate, spruce pressure plate, birch pressure plate, jungle pressure plate, acacia pressure plate, dark oak pressure plate, gold pressure plate, iron pressure plate
+	
+	(oak|regular|normal) [wood[en]] trapdoor¦s = minecraft:oak_trapdoor
+	(spruce|fir|redwood|pine) [wood[en]] trapdoor¦s = minecraft:spruce_trapdoor
+	birch [wood[en]] trapdoor¦s = minecraft:birch_trapdoor
+	jungle [wood[en]] trapdoor¦s = minecraft:jungle_trapdoor
+	acacia [wood[en]] trapdoor¦s = minecraft:acacia_trapdoor
+	dark oak [wood[en]] trapdoor¦s = minecraft:dark_oak_trapdoor
+	[any] trapdoor¦s = iron trapdoor, oak trapdoor, spruce trapdoor, birch trapdoor, jungle trapdoor, acacia trapdoor, dark oak trapdoor
+	
+	(oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:oak_fence_gate
+	[any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
+	
+	(oak|regular|normal) [wood[en]] door¦s = minecraft:oak_door
+	[any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
+	[any] door¦s = iron door, any wood door
 
 logic:
-    (inactive|unpowered) [redstone] repeater¦s = minecraft:unpowered_repeater
-    (active|powered) [redstone] repeater¦s = minecraft:powered_repeater
-    [redstone] repeater item¦s = minecraft:repeater
-    [any] [redstone] repeater¦s = unpowered repeater, powered repeater, repeater item
-    
-    (inactive|unpowered) [redstone] comparator¦s = minecraft:unpowered_comparator
-    (active|powered) [redstone] comparator¦s = minecraft:powered_comparator
-    [redstone] comparator item¦s = minecraft:comparator
-    [any] [redstone] comparator¦s = unpowered comparator, powered comparator, comparator item
+	(inactive|unpowered) [redstone] repeater¦s = minecraft:unpowered_repeater
+	(active|powered) [redstone] repeater¦s = minecraft:powered_repeater
+	[redstone] repeater item¦s = minecraft:repeater
+	[any] [redstone] repeater¦s = unpowered repeater, powered repeater, repeater item
+	
+	(inactive|unpowered) [redstone] comparator¦s = minecraft:unpowered_comparator
+	(active|powered) [redstone] comparator¦s = minecraft:powered_comparator
+	[redstone] comparator item¦s = minecraft:comparator
+	[any] [redstone] comparator¦s = unpowered comparator, powered comparator, comparator item
 
 	hopper¦s = minecraft:hopper
-    
+	
 new logic:
-    minecraft versions = 1.11 or newer
-    [redstone] observer¦s = minecraft:observer
+	minecraft versions = 1.11 or newer
+	[redstone] observer¦s = minecraft:observer

--- a/redstone.sk
+++ b/redstone.sk
@@ -1,0 +1,118 @@
+power sources:
+    redstone block¦s = minecraft:redstone_block
+    redstone [dust] block¦s = minecraft:redstone_wire
+    [any] redstone [dust] item¦s = minecraft:redstone
+    redstone [dust] = redstone block, redstone item
+    
+    lit redstone torch¦es = minecraft:redstone_torch
+    unlit redstone torch¦es = minecraft:unlit_redstone_torch
+    [any] redstone torch¦es = lit redstone torch, unlit redstone torch
+    
+    [redstone] lever¦s = minecraft:lever
+    stone pressure plate¦s = minecraft:stone_pressure_plate
+    (gold|light[ ][weight[ed]]) pressure plate¦s = minecraft:light_weighted_pressure_plate
+    (iron|heavy[ ][weight[ed]]) pressure plate¦s = minecraft:heavy_weighted_pressure_plate
+    (normal|uninverted) daylight (detector|sensor)¦s = minecraft:daylight_detector
+    [inverted] daylight (detector|sensor) [inverted]¦s = minecraft:inverted_daylight_detector
+    [any] daylight (detector|sensor)¦s = daylight detector, inverted daylight detector
+    stone button¦s = minecraft:stone_button
+    tripwire hook¦s = minecraft:tripwire_hook
+    trapped chest¦s = minecraft:trapped_chest
+
+activatables:
+    dispenser¦s = minecraft:dispenser
+    note block¦s = minecraft:note_block
+    dropper¦s = minecraft:dropper
+    tnt¦s = minecraft:tnt
+    
+    lit [redstone] lamp¦s = minecraft:lit_redstone_lamp
+    unlit [redstone] lamp¦s = minecraft:redstone_lamp
+    [any] redstone lamp¦s = lit redstone lamp, unlit redstone lamp
+    
+    normal piston¦s = minecraft:piston
+    sticky piston¦s = minecraft:sticky_piston
+    piston head¦s = minecraft:piston_head
+    (block 36|block moved by piston|moving block¦s) = minecraft:piston_extension
+
+    iron trapdoor¦s = minecraft:iron_trapdoor
+    
+    (spruce|fir|redwood|pine) [wood[en]] [fence] gate¦s = minecraft:spruce_fence_gate
+    birch [wood[en]] [fence] gate¦s = minecraft:birch_fence_gate
+    jungle [wood[en]] [fence] gate¦s = minecraft:jungle_fence_gate
+    acacia [wood[en]] [fence] gate¦s = minecraft:acacia_fence_gate
+    dark oak [wood[en]] [fence] gate¦s = minecraft:dark_oak_fence_gate
+    
+    iron door¦s = minecraft:iron_door
+    (spruce|fir|redwood|pine) [wood[en]] door¦s = minecraft:spruce_door
+    birch [wood[en]] door¦s = minecraft:birch_door
+    jungle [wood[en]] door¦s = minecraft:jungle_door
+    acacia [wood[en]] door¦s = minecraft:acacia_door
+    dark oak [wood[en]] door¦s = minecraft:dark_oak_door
+
+legacy wood activatables:
+    minecraft versions = 1.12 or older
+    wood[en] button¦s = minecraft:wooden_button
+    [any] button = stone button, wood button
+
+    [oak] wood[en] pressure plate¦s = minecraft:wooden_pressure_plate
+    [any] pressure plate¦s = stone pressure plate, wood pressure plate, gold pressure plate, iron pressure plate
+    
+    [oak] wood[en] trapdoor¦s = minecraft:trapdoor
+    [any] trapdoor¦s = wood trapdoor, iron trapdoor
+    
+    (oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:fence_gate
+    [any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
+    
+    (oak|regular|normal) [wood[en]] door¦s = minecraft:wooden_door
+    [any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
+    [any] door¦s = iron door, any wood door
+
+current wood activatables:
+    minecraft versions = 1.13 or newer
+    (oak|regular|normal) [wood[en]] button¦s = minecraft:oak_button
+    (spruce|fir|redwood|pine) [wood[en]] button¦s = minecraft:spruce_button
+    birch [wood[en]] button¦s = minecraft:birch_button
+    jungle [wood[en]] button¦s = minecraft:jungle_button
+    acacia [wood[en]] button¦s = minecraft:acacia_button
+    dark oak [wood[en]] button¦s = minecraft:dark_oak_button
+    [any] button¦s = stone button, oak button, spruce button, birch button, jungle button, acacia button, dark oak button
+
+    (oak|regular|normal) [wood[en]] pressure plate¦s = minecraft:oak_pressure_plate
+    (spruce|fir|redwood|pine) [wood[en]] pressure plate¦s = minecraft:spruce_pressure_plate
+    birch [wood[en]] pressure plate¦s = minecraft:birch_pressure_plate
+    jungle [wood[en]] pressure plate¦s = minecraft:jungle_pressure_plate
+    acacia [wood[en]] pressure plate¦s = minecraft:acacia_pressure_plate
+    dark oak [wood[en]] pressure plate¦s = minecraft:dark_oak_pressure_plate
+    [any] pressure plate¦s = stone pressure plate, oak pressure plate, spruce pressure plate, birch pressure plate, jungle pressure plate, acacia pressure plate, dark oak pressure plate, gold pressure plate, iron pressure plate
+    
+    (oak|regular|normal) [wood[en]] trapdoor¦s = minecraft:oak_trapdoor
+    (spruce|fir|redwood|pine) [wood[en]] trapdoor¦s = minecraft:spruce_trapdoor
+    birch [wood[en]] trapdoor¦s = minecraft:birch_trapdoor
+    jungle [wood[en]] trapdoor¦s = minecraft:jungle_trapdoor
+    acacia [wood[en]] trapdoor¦s = minecraft:acacia_trapdoor
+    dark oak [wood[en]] trapdoor¦s = minecraft:dark_oak_trapdoor
+    [any] trapdoor¦s = iron trapdoor, oak trapdoor, spruce trapdoor, birch trapdoor, jungle trapdoor, acacia trapdoor, dark oak trapdoor
+    
+    (oak|regular|normal) [wood[en]] [fence] gate¦s = minecraft:oak_fence_gate
+    [any] [wood[en]] gate¦s = oak gate, spruce gate, birch gate, jungle gate, acacia gate, dark oak gate
+    
+    (oak|regular|normal) [wood[en]] door¦s = minecraft:oak_door
+    [any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
+    [any] door¦s = iron door, any wood door
+
+logic:
+    (inactive|unpowered) [redstone] repeater¦s = minecraft:unpowered_repeater
+    (active|powered) [redstone] repeater¦s = minecraft:powered_repeater
+    [redstone] repeater item¦s = minecraft:repeater
+    [any] [redstone] repeater¦s = unpowered repeater, powered repeater, repeater item
+    
+    (inactive|unpowered) [redstone] comparator¦s = minecraft:unpowered_comparator
+    (active|powered) [redstone] comparator¦s = minecraft:powered_comparator
+    [redstone] comparator item¦s = minecraft:comparator
+    [any] [redstone] comparator¦s = unpowered comparator, powered comparator, comparator item
+
+	hopper¦s = minecraft:hopper
+    
+new logic:
+    minecraft versions = 1.11 or newer
+    [redstone] observer¦s = minecraft:observer


### PR DESCRIPTION
This is a first pass at a full category from the creative inventory with the new aliases system. I've tried to separate out the items in this category into logical subcategories based on the new ability to create freely named scopes for storing the aliases.

There is a notable issue here that I've discussed with bensku: the new aliases system currently doesn't support 1.13's shift to block states. These are essentially a reimagining of data values as named key-value pairs that represent various states of the block (a bit of a "duh" given the name "block states"). For example, what may have been `log:0` in 1.12 and below (a vertical oak log) would now be `oak_log[axis=y]` -- `axis` is a block state for blocks that can be placed along the three axes (such as logs and pillars), and `y` is one of the possible values (as are `x` and `z`, of course).

Because support for these is understandably not present yet, sub-states of blocks are not represented at all yet, e.g. the current aliases have support for different repeater delays (`1-tick-delay repeater`), while this file does not. I also haven't added any support for pre-1.13 block states yet via data values; I just wanted to get this PR up to get everyone's opinions on the general layout of how these files should be done (category naming, spacing, etc.), which is why I specifically requested reviews.

The last issue I can think of is that some of these aren't backward compatible with the old aliases, e.g. I realized while writing this that I forgot to make `diode` an alternate syntax for repeaters. I'll do another pass soon to try to make everything compatible with the current aliases.