### PR TITLE
Update brewing, food, decoration, and misc

### DIFF
--- a/brewing.sk
+++ b/brewing.sk
@@ -9,7 +9,7 @@ potions:
     awkward = - {"Potion": "minecraft:awkward"}
 
     night vision = - {"Potion": "minecraft:night_vision"}
-    (extended|long) night vision = - {"Potion": "minecraft:night_vision"}
+    (extended|long) night vision = - {"Potion": "minecraft:long_night_vision"}
 
     invisibility = - {"Potion": "minecraft:invisibility"}
     (extended|long) invisibility = - {"Potion": "minecraft:long_invisibility"}
@@ -19,7 +19,7 @@ potions:
     (empowered|strong|tier (2|II)) (leaping|jumping) = - {"Potion": "minecraft:strong_leaping"}
 
     fire resistance = - {"Potion": "minecraft:fire_resistance"}
-    (extended|long) fire resistance = - {"Potion": "minecraft:fire_resistance"}
+    (extended|long) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
 
     (speed|swiftness) = - {"Potion": "minecraft:swiftness"}
     (extended|long) (speed|swiftness) = - {"Potion": "minecraft:long_swiftness"}
@@ -89,10 +89,10 @@ unchanged ingredients:
 
 ingredients before flattening:
   minecraft version = 1.12.2 or older
-  (glistering|golden) melon[ slice]¦s = minecraft:speckled_melon
+  (glistering|gold[en]) melon[ slice]¦s = minecraft:speckled_melon
 
 ingredients after flattening:
-  (glistering|golden) melon[ slice]¦s = minecraft:glistering_melon_slice
+  (glistering|gold[en]) melon[ slice]¦s = minecraft:glistering_melon_slice
 
 update aquatic ingredients:
   minecraft version = 1.13 or newer

--- a/decoration.sk
+++ b/decoration.sk
@@ -123,9 +123,9 @@ decoratives before flattening:
 	{attached} torch¦es = minecraft:torch
 	chest¦s = minecraft:chest
 	(wet|moist|hydrated) farmland = minecraft:farmland {Damage:7}
-	[unlit] furnace¦s = minecraft:furnace
+	unlit furnace¦s = minecraft:furnace
 	lit furnace¦s = minecraft:lit_furnace
-	any furnace¦s = unlit furnace, lit furnace
+	[any] furnace¦s = unlit furnace, lit furnace
 	ladder¦s = minecraft:ladder
 	snow layer¦s = minecraft:snow_layer
 	iron bar¦s = minecraft:iron_bars

--- a/decoration.sk
+++ b/decoration.sk
@@ -7,8 +7,8 @@ unchanged decoratives:
 	(soil|farmland) [block¦s] = minecraft:farmland
 	cactus¦es = minecraft:cactus
 	jukebox¦es = minecraft:jukebox
-	huge brown mushroom block¦s = minecraft:brown_mushroom_block
-	huge red mushroom block¦s = minecraft:red_mushroom_block
+	[huge] brown mushroom block¦s = minecraft:brown_mushroom_block
+	[huge] red mushroom block¦s = minecraft:red_mushroom_block
 	vine¦s = minecraft:vine
 	enchant(ment|ing) table¦s = minecraft:enchanting_table
 	painting item¦s = minecraft:painting
@@ -123,9 +123,9 @@ decoratives before flattening:
 	{attached} torch¦es = minecraft:torch
 	chest¦s = minecraft:chest
 	(wet|moist|hydrated) farmland = minecraft:farmland {Damage:7}
-	unlit furnace¦s = minecraft:furnace
+	[unlit] furnace¦s = minecraft:furnace
 	lit furnace¦s = minecraft:lit_furnace
-	[any] furnace¦s = unlit furnace, lit furnace
+	any furnace¦s = unlit furnace, lit furnace
 	ladder¦s = minecraft:ladder
 	snow layer¦s = minecraft:snow_layer
 	iron bar¦s = minecraft:iron_bars
@@ -189,7 +189,7 @@ decoratives after flattening:
 	any (infested|silverfish) block¦s = infested stone, infested cobblestone, infested stone brick, infested mossy stone brick, infested cracked stone brick, infested chiseled stone brick
 
 	# Huge mushroom stems are their own block now
-	huge mushroom stem¦s = minecraft:mushroom_stem
+	[huge] mushroom stem¦s = minecraft:mushroom_stem
 
 	# End Portal Frame
 	{end portal eye state}:

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -3,7 +3,7 @@
 # Most of the foods are simple items that have always existed. These didn't change in 1.13.
 unchanged foods:
     apple¦s = minecraft:apple
-    baked potato¦s = minecraft:baked_potato
+    baked potato¦es = minecraft:baked_potato
     beetroot¦s = minecraft:beetroot
     beetroot (stew|soup)¦s = minecraft:beetroot_soup
     [loa(f|ves) of] bread = minecraft:bread
@@ -13,7 +13,7 @@ unchanged foods:
     (cooked beef|steak¦s) = minecraft:cooked_beef
     cooked chicken¦s = minecraft:cooked_chicken
     cooked mutton¦s = minecraft:cooked_mutton
-    cooked pork[chop]¦s = minecraft:cooked_porkchop
+    cooked pork[chop¦s] = minecraft:cooked_porkchop
     cooked rabbit¦s = minecraft:cooked_rabbit
     cookie¦s = minecraft:cookie
     golden carrot¦s = minecraft:golden_carrot
@@ -33,11 +33,11 @@ unchanged foods:
 # Before the flattening in 1.13, some foods used data values.
 foods before flattening:
     minecraft version = 1.12.2 or older
-    [raw] (fish¦es|(cod|fish) [fillet]¦s) = minecraft:fish
+    [raw] (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:fish
     [raw] salmon [fillet]¦s = minecraft:fish {Damage:1}
     clownfish¦es = minecraft:fish {Damage:2}
     pufferfish¦es = minecraft:fish {Damage:3}
-    cooked (fish¦es|(cod|fish) [fillet]¦s) = minecraft:cooked_fish
+    cooked (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:cooked_fish
     cooked salmon [fillet]¦s = minecraft:cooked_fish {Damage:1}
 
     [normal] golden apple = minecraft:golden_apple {Damage:0}
@@ -66,7 +66,7 @@ categories:
     any cod [fillet]¦s = raw cod, cooked cod
     any salmon [fillet]¦s = raw salmon, cooked salmon
     any raw fish¦es = raw cod, raw salmon, pufferfish, tropical fish
-    any cooked (fish¦es|fish [fillet¦s]) = cooked cod, cooked salmon
+    any cooked (fish¦es|fish fillet¦s) = cooked cod, cooked salmon
     any fish¦es = any raw fish, any cooked fish
     
     any golden apple = normal golden apple, enchanted golden apple

--- a/misc.sk
+++ b/misc.sk
@@ -64,20 +64,20 @@ random items:
 	prismarine crystal¦s = minecraft:prismarine_crystals
 	rabbit hide¦s = minecraft:rabbit_hide
 	
-{firework types}:
-	(0|zero) = {Fireworks:{Flight:0}}
-	(1|one) =  {Fireworks:{Flight:1}}
-	(2|two) = - {Fireworks:{Flight:2}}
-	(3|three) = - {Fireworks:{Flight:3}}
+fireworks:
+	{firework types}:
+		(0|zero|immediate) = {Fireworks:{Flight:0}}
+		(1|one|short) = {Fireworks:{Flight:1}}
+		(2|two|medium) = - {Fireworks:{Flight:2}}
+		(3|three|long) = - {Fireworks:{Flight:3}}
 	
 before flattening:
 	minecraft version = 1.12.2 or older
-	(firework|firework rocket)¦s = fireworks
-	[(flight|duration|flight duration) {firework types} ] (firework|firework rocket)¦s = fireworks
+	[(flight|duration|flight duration) {firework types} ] firework [rocket]¦s = fireworks
 	
 after flattening:
 	minecraft version = 1.13 or newer
-	[(flight|duration|flight duration) {firework types} ] (firework|firework rocket)¦s = firework_rocket
+	[(flight|duration|flight duration) {firework types} ] firework [rocket]¦s = firework_rocket
 
 plants:
 	pumpkin seeds = minecraft:pumpkin_seeds

--- a/misc.sk
+++ b/misc.sk
@@ -50,19 +50,34 @@ random items:
 	sugar = minecraft:sugar
 	ender pearl¦s = minecraft:ender_pearl
 	blaze rod¦s = minecraft:blaze_rod
-	nether wart = minecraft:nether_wart
+	nether wart¦s = minecraft:nether_wart
 	(ender eye¦s|eye¦s of ender) = minecraft:ender_eye
 	(bottle¦s o' enchanting|xp bottle¦s|experience bottle¦s) = minecraft:experience_bottle
 	fire charge¦s = minecraft:fire_charge
 	(book and quill¦s|writable book¦s) = minecraft:writable_book
-	# TODO maps?
+	[empty] map = minecraft:map
+	filled map = minecraft:filled_map
 	nether star¦s = minecraft:nether_star
-	# TODO fireworks
 	nether brick¦s = minecraft:nether_brick
 	nether quartz = minecraft:quartz
 	prismarine shard¦s = minecraft:prismarine_shard
 	prismarine crystal¦s = minecraft:prismarine_crystals
 	rabbit hide¦s = minecraft:rabbit_hide
+	
+{firework types}:
+	(0|zero) = {Fireworks:{Flight:0}}
+	(1|one) =  {Fireworks:{Flight:1}}
+	(2|two) = - {Fireworks:{Flight:2}}
+	(3|three) = - {Fireworks:{Flight:3}}
+	
+before flattening:
+	minecraft version = 1.12.2 or older
+	(firework|firework rocket)¦s = fireworks
+	[(flight|duration|flight duration) {firework types} ] (firework|firework rocket)¦s = fireworks
+	
+after flattening:
+	minecraft version = 1.13 or newer
+	[(flight|duration|flight duration) {firework types} ] (firework|firework rocket)¦s = firework_rocket
 
 plants:
 	pumpkin seeds = minecraft:pumpkin_seeds


### PR DESCRIPTION
Brewing
  > Fixed mistakes in potions (long night vision and fire resistance)
  > Replaced "golden" with "gold[en]" in glistering melons

Decoration
  > Updated furnaces (makes more sense with what people would use IMO)
  > huge -> [huge] in mushrooms

Foodstuffs
  > Grammatical fixes for baked potatoes and porkchops
  > Updated fishes for "more proper plurals" (may be wrong)

Misc
  > Grammatical fixes for nether warts
  > Added empty maps and filled maps
  > Added fireworks (durations 0 - 3 (default))