### PR TITLE
Rotations and Variations

### DIFF
--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -23,6 +23,23 @@ data values:
 		[dark] green = - {Damage:13}
 		red = - {Damage:14}
 		black = - {Damage:15}
+	{opposite colored}:
+		white = - {Damage:15}
+		orange = - {Damage:14}
+		magenta = - {Damage:13}
+		light blue = - {Damage:12}
+		yellow = - {Damage:11}
+		(lime [green]|light green) = - {Damage:10}
+		pink = - {Damage:9}
+		[dark] gr(a|e)y = - {Damage:8}
+		light gr(a|e)y = - {Damage:7}
+		cyan = - {Damage:6}
+		purple = - {Damage:5}
+		blue = - {Damage:4}
+		brown = - {Damage:3}
+		[dark] green = - {Damage:2}
+		red = - {Damage:1}
+		black = - {Damage:0}
 	# For blocks that were colored via ID even in 1.12. Rarely used, but it needs to be a different
 	# variation than the 1.13 ID-based one because 'light_gray' used to be 'silver' in IDs.
 	{old colored IDs}:
@@ -47,50 +64,50 @@ data values:
 	# Dispenser, dropper, pistons, end rods.
 	{orientable}:
 		{default} = - {Damage:1}
-		(down[ward[s]]( |-)[(facing|pointing)]) = - {Damage:0}
-		(up[ward[s]]( |-)[(facing|pointing)]) = - {Damage:1}
-		(north[ward[s]]( |-)[(facing|pointing)]) = - {Damage:2}
-		(south[ward[s]]( |-)[(facing|pointing)]) = - {Damage:3}
-		(west[ward[s]]( |-)[(facing|pointing)]) = - {Damage:4}
-		(east[ward[s]]( |-)[(facing|pointing)]) = - {Damage:5}
+		down[ward[s]][( |-)(facing|pointing)] = - {Damage:0}
+		up[ward[s]][( |-)(facing|pointing)] = - {Damage:1}
+		north[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
+		south[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+		west[ward[s]][( |-)(facing|pointing)] = - {Damage:4}
+		east[ward[s]][( |-)(facing|pointing)] = - {Damage:5}
 
 	# For all stairs
 	{stair direction}:
 		{default} = - {Damage:0}
-		[right[( |-)]side up] (east[ward[s]]( |-)[(facing|pointing)]) = - {Damage:0}
-		[right[( |-)]side up] (west[ward[s]]( |-)[(facing|pointing)]) = - {Damage:1}
-		[right[( |-)]side up] (south[ward[s]]( |-)[(facing|pointing)]) = - {Damage:2}
-		[right[( |-)]side up] (north[ward[s]]( |-)[(facing|pointing)]) = - {Damage:3}
-		up[( |-)]side down (east[ward[s]]( |-)[(facing|pointing)]) = - {Damage:4}
-		up[( |-)]side down (west[ward[s]]( |-)[(facing|pointing)]) = - {Damage:5}
-		up[( |-)]side down (south[ward[s]]( |-)[(facing|pointing)]) = - {Damage:6}
-		up[( |-)]side down (north[ward[s]]( |-)[(facing|pointing)]) = - {Damage:7}
+		[right[( |-)]side up] east[ward[s]][( |-)(facing|pointing)] = - {Damage:0}
+		[right[( |-)]side up] west[ward[s]][( |-)(facing|pointing)] = - {Damage:1}
+		[right[( |-)]side up] south[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
+		[right[( |-)]side up] north[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+		up[( |-)]side down east[ward[s]][( |-)(facing|pointing)] = - {Damage:4}
+		up[( |-)]side down west[ward[s]][( |-)(facing|pointing)] = - {Damage:5}
+		up[( |-)]side down south[ward[s]][( |-)(facing|pointing)] = - {Damage:6}
+		up[( |-)]side down north[ward[s]][( |-)(facing|pointing)] = - {Damage:7}
 
 	# For blocks that can be attached to sides of another block, such as torches.
 	{attached}:
 		{default} = - {Damage:5}
-		(down[ward[s]]( |-)[(facing|pointing)]) = - {Damage:0}
-		(east[ward[s]]( |-)[(facing|pointing)]) wall = - {Damage:1}
-		(west[ward[s]]( |-)[(facing|pointing)]) wall = - {Damage:2}
-		(south[ward[s]]( |-)[(facing|pointing)]) wall = - {Damage:3}
-		(north[ward[s]]( |-)[(facing|pointing)]) wall = - {Damage:4}
-		(up[ward[s]]( |-)[(facing|pointing)]|floor) = - {Damage:5}
+		down[ward[s]][( |-)(facing|pointing)] = - {Damage:0}
+		east[ward[s]][( |-)(facing|pointing)] wall = - {Damage:1}
+		west[ward[s]][( |-)(facing|pointing)] wall = - {Damage:2}
+		south[ward[s]][( |-)(facing|pointing)] wall = - {Damage:3}
+		north[ward[s]][( |-)(facing|pointing)] wall = - {Damage:4}
+		up[ward[s]][( |-)(facing|pointing)]|floor = - {Damage:5}
 
 	# For blocks that can be attached to sides of another block and toggled, namely buttons.
 	{attached toggleable}:
 		{default} = - {Damage:5}
-		[(unpressed|inactive)] (down[ward[s]]( |-)[(facing|pointing)]) = - {Damage:0}
-		[(unpressed|inactive)] (east[ward[s]]( |-)[(facing|pointing)]) = - {Damage:1}
-		[(unpressed|inactive)] (west[ward[s]]( |-)[(facing|pointing)]) = - {Damage:2}
-		[(unpressed|inactive)] (south[ward[s]]( |-)[(facing|pointing)]) = - {Damage:3}
-		[(unpressed|inactive)] (north[ward[s]]( |-)[(facing|pointing)]) = - {Damage:4}
-		[(unpressed|inactive)] (up[ward[s]]( |-)[(facing|pointing)]) = - {Damage:5}
-		(pressed|active) (down[ward[s]]( |-)[(facing|pointing)]) = - {Damage:8}
-		(pressed|active) (east[ward[s]]( |-)[(facing|pointing)]) = - {Damage:9}
-		(pressed|active) (west[ward[s]]( |-)[(facing|pointing)]) = - {Damage:10}
-		(pressed|active) (south[ward[s]]( |-)[(facing|pointing)]) = - {Damage:11}
-		(pressed|active) (north[ward[s]]( |-)[(facing|pointing)]) = - {Damage:12}
-		(pressed|active) (up[ward[s]]( |-)[(facing|pointing)]) = - {Damage:13}
+		[(unpressed|inactive)] down[ward[s]][( |-)(facing|pointing)] = - {Damage:0}
+		[(unpressed|inactive)] east[ward[s]][( |-)(facing|pointing)] = - {Damage:1}
+		[(unpressed|inactive)] west[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
+		[(unpressed|inactive)] south[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+		[(unpressed|inactive)] north[ward[s]][( |-)(facing|pointing)] = - {Damage:4}
+		[(unpressed|inactive)] up[ward[s]][( |-)(facing|pointing)] = - {Damage:5}
+		(pressed|active) down[ward[s]][( |-)(facing|pointing)] = - {Damage:8}
+		(pressed|active) east[ward[s]][( |-)(facing|pointing)] = - {Damage:9}
+		(pressed|active) west[ward[s]][( |-)(facing|pointing)] = - {Damage:10}
+		(pressed|active) south[ward[s]][( |-)(facing|pointing)] = - {Damage:11}
+		(pressed|active) north[ward[s]][( |-)(facing|pointing)] = - {Damage:12}
+		(pressed|active) up[ward[s]][( |-)(facing|pointing)] = - {Damage:13}
 
 	# For wood types defined by data values in older versions. Not all wooden blocks can use this,
 	# just ones that were all stored in one ID using DVs 0-5 to represent them.
@@ -129,20 +146,20 @@ block states:
 	# Dispenser, dropper, pistons, end rods.
 	{orientable}:
 		{default} = -[facing=up]
-		(down[ward[s]]( |-)[(facing|pointing)]) = -[facing=down]
-		(up[ward[s]]( |-)[(facing|pointing)]) = -[facing=up]
-		(north[ward[s]]( |-)[(facing|pointing)]) = -[facing=north]
-		(south[ward[s]]( |-)[(facing|pointing)]) = -[facing=south]
-		(west[ward[s]]( |-)[(facing|pointing)]) = -[facing=west]
-		(east[ward[s]]( |-)[(facing|pointing)]) = -[facing=east]
+		down[ward[s]][( |-)(facing|pointing)] = -[facing=down]
+		up[ward[s]][( |-)(facing|pointing)] = -[facing=up]
+		north[ward[s]][( |-)(facing|pointing)] = -[facing=north]
+		south[ward[s]][( |-)(facing|pointing)] = -[facing=south]
+		west[ward[s]][( |-)(facing|pointing)] = -[facing=west]
+		east[ward[s]][( |-)(facing|pointing)] = -[facing=east]
 
 	# For blocks that can only point in four directions.
 	{directional}:
 		{default} = -[facing=east]
-		(north[ward[s]]( |-)[(facing|pointing)]) = -[facing=north]
-		(south[ward[s]]( |-)[(facing|pointing)]) = -[facing=south]
-		(west[ward[s]]( |-)[(facing|pointing)]) = -[facing=west]
-		(east[ward[s]]( |-)[(facing|pointing)]) = -[facing=east]
+		north[ward[s]][( |-)(facing|pointing)] = -[facing=north]
+		south[ward[s]][( |-)(facing|pointing)] = -[facing=south]
+		west[ward[s]][( |-)(facing|pointing)] = -[facing=west]
+		east[ward[s]][( |-)(facing|pointing)] = -[facing=east]
 
 	# For anything that can exist in either the top or bottom half of a block (slabs), can be flipped
 	# (stairs), or that has top and bottom halves (double plants, doors, etc.)

--- a/decoration.sk
+++ b/decoration.sk
@@ -331,3 +331,63 @@ update aquatic:
 		(trio of|[bundle of] three) = -[pickles=3]
 		[bundle of] four = -[pickles=4]
 	({waterlogged} {pickle count}|{pickle count} {waterlogged}) sea pickle¦s = minecraft:sea_pickle
+	
+skulls:
+	{skull floor orientations}:
+		north[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:0}
+		north-northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:1}
+		northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:2}
+		east-northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:3}
+		east[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:4}
+		east-southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:5}
+		southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:6}
+		south-southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:7}
+		south[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:8}
+		south-southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:9}
+		southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:10}
+		west-southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:11}
+		west[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:12}
+		west-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:13}
+		northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:14}
+		north-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:15}
+old skulls:
+	minecraft version = 1.12.2 or older
+	{skull types}:
+		skelet(on|al) (skull|head) = - {SkullType:0} 
+		wither skle(on|al) (skull|head) = - {SkullType:1}
+		zombi(e|fied) = - {SkullType:2}
+		player (head|skull) = - {SkullType:3}
+		creeper (head|skull) = - {SkullType:4}
+	{skull wall orientations}:
+		north[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
+		south[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+		east[ward[s]][( |-)(facing|pointing)] = - {Damage:4}
+		west[ward[s]][( |-)(facing|pointing)] = - {Damage:5
+	
+combat update skulls:
+	minecraft version = 1.9 or newer
+	[ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
+	#skulls on walls and floors
+	({skull wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
+	
+skulls before flattening:
+	minecraft version = 1.12.2 or older
+	{skull types} item¦s = minecraft:skull
+	#skulls on walls and floors
+	({skull wall orientations}|{skull floor orientations}) {skull types} = minecraft:skull
+	
+skulls after flattening:
+	minecraft version = 1.13 or newer
+	skelet(on|al) (skull|head) item¦s = minecraft:skeleton_skull
+	wither skle(on|al) (skull|head) item¦s = minecraft:wither_skeleton_skull
+	zombi(e|fied) (head|skull) item¦s = minecraft:zombie_head
+	player (head|skull) item¦s = minecraft:player_head
+	creeper (head|skull) item¦s = minecraft:creeper_head
+	[ender[ ]]dragon (head|skull) item¦s = minecraft:dragon_head
+	#skulls on walls and floors
+	({directional}|{skulls floor orientations}) skelet(on|al) (skull|head) = minecraft:skeleton_wall_skull
+	({directional}|{skulls floor orientations}) wither skle(on|al) (skull|head) = minecraft:wither_skeleton_wall_skull
+	({directional}|{skulls floor orientations}) zombi(e|fied) (head|skull) = minecraft:zombie_wall_head
+	({directional}|{skulls floor orientations}) player (head|skull) = minecraft:player_wall_head
+	({directional}|{skulls floor orientations}) creeper (head|skull) = minecraft:creeper_wall_head
+	({directional}|{skulls floor orientations})[ender[ ]]dragon (head|skull) = minecraft:dragon_wall_head

--- a/decoration.sk
+++ b/decoration.sk
@@ -375,7 +375,7 @@ old orientations:
 		west[ward[s]][( |-)(facing|pointing)] = - {Damage:5}
 	
 combat update skulls:
-	minecraft version = 1.9 or newer
+	minecraft version = 1.9 to 1.12.2
 	[ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
 	#skulls on walls and floors
 	({wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull)¦s = minecraft:skull {SkullType:5}

--- a/decoration.sk
+++ b/decoration.sk
@@ -115,10 +115,6 @@ decoratives before flattening:
 	[floor] sign¦s = minecraft:standing_sign
 	any sign¦s = wall sign, floor sign
 
-	# Banners
-	wall banner = minecraft:wall_banner
-	[standing] banner¦s = minecraft:standing_banner, minecraft:banner
-
 	# Miscellaneous
 	{attached} torch¦es = minecraft:torch
 	chest¦s = minecraft:chest
@@ -212,10 +208,6 @@ decoratives after flattening:
 
 		# Glazed terracotta was slightly changed in 1.13 because silver became light_gray in IDs.
 	{colored} glazed terracotta [block¦s] = -glazed_terracotta
-
-	# Banners
-	{directional} {colored} wall banner = -wall_banner
-	{colored} [standing] banner¦s = -banner
 
 	# Signs
 	{waterloggable} {directional} wall sign¦s = minecraft:wall_sign
@@ -332,7 +324,7 @@ update aquatic:
 		[bundle of] four = -[pickles=4]
 	({waterlogged} {pickle count}|{pickle count} {waterlogged}) sea pickle¦s = minecraft:sea_pickle
 	
-skulls:
+unchanged orientations:
 	{skull floor orientations}:
 		north[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:0}
 		north-northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:1}
@@ -350,7 +342,25 @@ skulls:
 		west-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:13}
 		northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:14}
 		north-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:15}
-old skulls:
+	{banner standing orientations}:
+		south[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:0}
+		south-southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:1}
+		southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:2}
+		west-southwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:3}
+		west[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:4}
+		west-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:5}
+		northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:6}
+		north-northwest[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:7}
+		north[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:8}
+		north-northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:9}
+		northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:10}
+		east-northeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:11}
+		east[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:12}
+		east-southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:13}
+		southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:14}
+		south-southeast[ward[s]][( |-)rotat(ion|ed)] = - {Damage:1,Rot:15}
+		
+old orientations:
 	minecraft version = 1.12.2 or older
 	{skull types}:
 		skelet(on|al) (skull|head) = - {SkullType:0} 
@@ -358,25 +368,29 @@ old skulls:
 		zombi(e|fied) = - {SkullType:2}
 		player (head|skull) = - {SkullType:3}
 		creeper (head|skull) = - {SkullType:4}
-	{skull wall orientations}:
-		north[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
-		south[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+	{wall orientations}:
+		north[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
+		south[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
 		east[ward[s]][( |-)(facing|pointing)] = - {Damage:4}
-		west[ward[s]][( |-)(facing|pointing)] = - {Damage:5
+		west[ward[s]][( |-)(facing|pointing)] = - {Damage:5}
 	
 combat update skulls:
 	minecraft version = 1.9 or newer
 	[ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
 	#skulls on walls and floors
-	({skull wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
+	({wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
 	
-skulls before flattening:
+directionals before flattening:
 	minecraft version = 1.12.2 or older
 	{skull types} item¦s = minecraft:skull
 	#skulls on walls and floors
-	({skull wall orientations}|{skull floor orientations}) {skull types} = minecraft:skull
+	({wall orientations}|{skull floor orientations}) {skull types} = minecraft:skull
+	#BANNERS
+	{wall orientations} {opposite colored} wall banner = minecraft:wall_banner
+	{banner standing orientations} {opposite colored} [standing] banner¦s = minecraft:banner
+	{opposite colored} banner item¦s = -banner
 	
-skulls after flattening:
+directionals after flattening:
 	minecraft version = 1.13 or newer
 	skelet(on|al) (skull|head) item¦s = minecraft:skeleton_skull
 	wither skle(on|al) (skull|head) item¦s = minecraft:wither_skeleton_skull
@@ -391,3 +405,7 @@ skulls after flattening:
 	({directional}|{skulls floor orientations}) player (head|skull) = minecraft:player_wall_head
 	({directional}|{skulls floor orientations}) creeper (head|skull) = minecraft:creeper_wall_head
 	({directional}|{skulls floor orientations})[ender[ ]]dragon (head|skull) = minecraft:dragon_wall_head
+	# BANNERS
+	{directional} {colored} wall banner = -wall_banner
+	{banner standing orientations} {colored} [standing] banner¦s = -banner
+	{colored} banner item¦s = -banner

--- a/decoration.sk
+++ b/decoration.sk
@@ -363,11 +363,11 @@ unchanged orientations:
 old orientations:
 	minecraft version = 1.12.2 or older
 	{skull types}:
-		skelet(on|al) (skull|head) = - {SkullType:0} 
-		wither skle(on|al) (skull|head) = - {SkullType:1}
-		zombi(e|fied) = - {SkullType:2}
-		player (head|skull) = - {SkullType:3}
-		creeper (head|skull) = - {SkullType:4}
+		skelet(on|al) (skull|head)¦s = - {SkullType:0} 
+		wither skle(on|al) (skull|head)¦s = - {SkullType:1}
+		zombi(e|fied) (head|skull)¦s = - {SkullType:2}
+		player (head|skull)¦s = - {SkullType:3}
+		creeper (head|skull)¦s = - {SkullType:4}
 	{wall orientations}:
 		north[ward[s]][( |-)(facing|pointing)] = - {Damage:3}
 		south[ward[s]][( |-)(facing|pointing)] = - {Damage:2}
@@ -378,7 +378,7 @@ combat update skulls:
 	minecraft version = 1.9 or newer
 	[ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
 	#skulls on walls and floors
-	({wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull) item¦s = minecraft:skull {SkullType:5}
+	({wall orientations}|{skull floor orientations}) [ender[ ]]dragon (head|skull)¦s = minecraft:skull {SkullType:5}
 	
 directionals before flattening:
 	minecraft version = 1.12.2 or older
@@ -386,26 +386,33 @@ directionals before flattening:
 	#skulls on walls and floors
 	({wall orientations}|{skull floor orientations}) {skull types} = minecraft:skull
 	#BANNERS
-	{wall orientations} {opposite colored} wall banner = minecraft:wall_banner
+	{wall orientations} {opposite colored} wall banner¦s = minecraft:wall_banner
 	{banner standing orientations} {opposite colored} [standing] banner¦s = minecraft:banner
 	{opposite colored} banner item¦s = -banner
 	
 directionals after flattening:
 	minecraft version = 1.13 or newer
 	skelet(on|al) (skull|head) item¦s = minecraft:skeleton_skull
-	wither skle(on|al) (skull|head) item¦s = minecraft:wither_skeleton_skull
+	wither skelet(on|al) (skull|head) item¦s = minecraft:wither_skeleton_skull
 	zombi(e|fied) (head|skull) item¦s = minecraft:zombie_head
 	player (head|skull) item¦s = minecraft:player_head
 	creeper (head|skull) item¦s = minecraft:creeper_head
 	[ender[ ]]dragon (head|skull) item¦s = minecraft:dragon_head
-	#skulls on walls and floors
-	({directional}|{skulls floor orientations}) skelet(on|al) (skull|head) = minecraft:skeleton_wall_skull
-	({directional}|{skulls floor orientations}) wither skle(on|al) (skull|head) = minecraft:wither_skeleton_wall_skull
-	({directional}|{skulls floor orientations}) zombi(e|fied) (head|skull) = minecraft:zombie_wall_head
-	({directional}|{skulls floor orientations}) player (head|skull) = minecraft:player_wall_head
-	({directional}|{skulls floor orientations}) creeper (head|skull) = minecraft:creeper_wall_head
-	({directional}|{skulls floor orientations})[ender[ ]]dragon (head|skull) = minecraft:dragon_wall_head
+	#skulls on walls
+	{directional} skelet(on|al) (skull|head)¦s = minecraft:skeleton_wall_skull
+	{directional} wither skle(on|al) (skull|head)¦s = minecraft:wither_skeleton_wall_skull
+	{directional} zombi(e|fied) (head|skull)¦s = minecraft:zombie_wall_head
+	{directional} player (head|skull)¦s = minecraft:player_wall_head
+	{directional} creeper (head|skull)¦s = minecraft:creeper_wall_head
+	{directional} [ender[ ]]dragon (head|skull)¦s = minecraft:dragon_wall_head
+	#skulls on floors
+	{skull floor orientations} skelet(on|al) (skull|head)¦s = minecraft:skeleton_skull
+	{skull floor orientations} wither skelet(on|al) (skull|head)¦s = minecraft:wither_skeleton_skull
+	{skull floor orientations} zombi(e|fied) (head|skull)¦s = minecraft:zombie_head
+	{skull floor orientations} player (head|skull)¦s = minecraft:player_head
+	{skull floor orientations} creeper (head|skull)¦s = minecraft:creeper_head
+	{skull floor orientations} [ender[ ]]dragon (head|skull)¦s = minecraft:dragon_head
 	# BANNERS
-	{directional} {colored} wall banner = -wall_banner
+	{directional} {colored} wall banner¦s = -wall_banner
 	{banner standing orientations} {colored} [standing] banner¦s = -banner
 	{colored} banner item¦s = -banner


### PR DESCRIPTION
Decoration
  > Added mob heads/skulls with floor rotations and wall directionals
  > Added banners with floor rotations, wall directionals, and plain colors

Global Variations
  > Updated various directionals and orientations
  > Added `opposite colored` for 1.12.2 and older (some colored items had black as 0 and white as 15)