### PR TITLE
Horse armor update / Foodstuff update

### DIFF
--- a/combat.sk
+++ b/combat.sk
@@ -112,15 +112,15 @@ weapons:
 
 horse armor old:
 	minecraft version = 1.12.2 or older
-	iron horse (armo[u]r|barding) = minecraft:iron_barding
-	gold[en] horse (armo[u]r|barding) = minecraft:gold_barding
-	diamond horse (armo[u]r|barding) = minecraft:diamond_barding
+	iron (horse armo[u]r|barding) = minecraft:iron_barding
+	gold[en] (horse armo[u]r|barding) = minecraft:gold_barding
+	diamond (horse armo[u]r|barding) = minecraft:diamond_barding
 	[any] horse armo[u]r = iron horse armor, gold horse armor, diamond horse armor
 
 horse armor new:
 	minecraft version = 1.13 or newer
-	iron horse (armo[u]r|barding) = minecraft:iron_horse_armor
-	gold[en] horse (armo[u]r|barding) = minecraft:golden_horse_armor
-	diamond horse (armo[u]r|barding) = minecraft:diamond_horse_armor
+	iron (horse armo[u]r|barding) = minecraft:iron_horse_armor
+	gold[en] (horse armo[u]r|barding) = minecraft:golden_horse_armor
+	diamond (horse armo[u]r|barding) = minecraft:diamond_horse_armor
 
 	[any] horse armo[u]r = iron horse armor, gold horse armor, diamond horse armor

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -2,92 +2,92 @@
 
 # Most of the foods are simple items that have always existed. These didn't change in 1.13.
 unchanged foods:
-    apple¦s = minecraft:apple
-    baked potato¦es = minecraft:baked_potato
-    beetroot¦s = minecraft:beetroot
-    beetroot (stew|soup)¦s = minecraft:beetroot_soup
-    [loa(f|ves) of] bread = minecraft:bread
-    cake¦s = minecraft:cake
-    carrot¦s = minecraft:carrot
-    chorus fruit¦s = minecraft:chorus_fruit
-    (cooked beef|steak¦s) = minecraft:cooked_beef
-    cooked chicken¦s = minecraft:cooked_chicken
-    cooked mutton¦s = minecraft:cooked_mutton
-    cooked pork[chop¦s] = minecraft:cooked_porkchop
-    cooked rabbit¦s = minecraft:cooked_rabbit
-    cookie¦s = minecraft:cookie
-    golden carrot¦s = minecraft:golden_carrot
-    mushroom (stew|soup)¦s = minecraft:mushroom_stew
-    poisonous potato¦es = minecraft:poisonous_potato
-    potato¦es = minecraft:potato
-    pumpkin pie¦s = minecraft:pumpkin_pie
-    rabbit (stew|soup)¦s = minecraft:rabbit_stew
-    [raw] beef = minecraft:beef
-    raw chicken¦s = minecraft:chicken
-    [raw] mutton¦s = minecraft:mutton
-    [raw] pork[chop]¦s = minecraft:porkchop
-    raw rabbit¦s = minecraft:rabbit
-    rotten flesh = minecraft:rotten_flesh
-    spider eye¦s = minecraft:spider_eye
+	apple¦s = minecraft:apple
+	baked potato¦es = minecraft:baked_potato
+	beetroot¦s = minecraft:beetroot
+	beetroot (stew|soup)¦s = minecraft:beetroot_soup
+	[loa(f|ves) of] bread = minecraft:bread
+	cake¦s = minecraft:cake
+	carrot¦s = minecraft:carrot
+	chorus fruit¦s = minecraft:chorus_fruit
+	(cooked beef|steak¦s) = minecraft:cooked_beef
+	cooked chicken¦s = minecraft:cooked_chicken
+	cooked mutton¦s = minecraft:cooked_mutton
+	cooked pork[chop¦s] = minecraft:cooked_porkchop
+	cooked rabbit¦s = minecraft:cooked_rabbit
+	cookie¦s = minecraft:cookie
+	golden carrot¦s = minecraft:golden_carrot
+	mushroom (stew|soup)¦s = minecraft:mushroom_stew
+	poisonous potato¦es = minecraft:poisonous_potato
+	potato¦es = minecraft:potato
+	pumpkin pie¦s = minecraft:pumpkin_pie
+	rabbit (stew|soup)¦s = minecraft:rabbit_stew
+	[raw] beef = minecraft:beef
+	[raw] chicken¦s = minecraft:chicken
+	[raw] mutton¦s = minecraft:mutton
+	[raw] pork[chop]¦s = minecraft:porkchop
+	[raw] rabbit¦s = minecraft:rabbit
+	rotten flesh = minecraft:rotten_flesh
+	spider eye¦s = minecraft:spider_eye
 
 # Before the flattening in 1.13, some foods used data values.
 foods before flattening:
-    minecraft version = 1.12.2 or older
-    [raw] (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:fish
-    [raw] salmon [fillet]¦s = minecraft:fish {Damage:1}
-    clownfish¦es = minecraft:fish {Damage:2}
-    pufferfish¦es = minecraft:fish {Damage:3}
-    cooked (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:cooked_fish
-    cooked salmon [fillet]¦s = minecraft:cooked_fish {Damage:1}
+	minecraft version = 1.12.2 or older
+	[raw] (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:fish
+	[raw] salmon [fillet]¦s = minecraft:fish {Damage:1}
+	clownfish¦es = minecraft:fish {Damage:2}
+	pufferfish¦es = minecraft:fish {Damage:3}
+	cooked (fish¦es|cod [fillet]¦s|fish fillet¦s) = minecraft:cooked_fish
+	cooked salmon [fillet]¦s = minecraft:cooked_fish {Damage:1}
 
-    [normal] golden apple = minecraft:golden_apple {Damage:0}
-    (enchanted golden|notch) apple = minecraft:golden_apple {Damage:1}
-    
-    melon [slice]¦s = minecraft:melon
+	[normal] golden apple = minecraft:golden_apple {Damage:0}
+	(enchanted golden|notch) apple = minecraft:golden_apple {Damage:1}
+	
+	melon [slice]¦s = minecraft:melon
 
 # Foods whose IDs were changed as part of the ID flattening in 1.13.
 foods after flattening:
-    minecraft version = 1.13 or newer
-    [raw] cod [fillet]¦s = minecraft:cod
-    cooked cod [fillet]¦s = minecraft:cooked_cod
-    [raw] salmon [fillet]¦s = minecraft:salmon
-    cooked salmon [fillet]¦s = minecraft:cooked_salmon
-    pufferfish¦es = minecraft:pufferfish
-    tropical fish¦es = minecraft:tropical_fish
-    
-    [normal] golden apple = minecraft:golden_apple
-    (enchanted golden|notch) apple = minecraft:enchanted_golden_apple
-    
-    melon [slice]¦s = minecraft:melon_slice
-    dried kelp¦s = minecraft:dried_kelp
+	minecraft version = 1.13 or newer
+	[raw] cod [fillet]¦s = minecraft:cod
+	cooked cod [fillet]¦s = minecraft:cooked_cod
+	[raw] salmon [fillet]¦s = minecraft:salmon
+	cooked salmon [fillet]¦s = minecraft:cooked_salmon
+	pufferfish¦es = minecraft:pufferfish
+	tropical fish¦es = minecraft:tropical_fish
+	
+	[normal] golden apple = minecraft:golden_apple
+	(enchanted golden|notch) apple = minecraft:enchanted_golden_apple
+	
+	melon [slice]¦s = minecraft:melon_slice
+	dried kelp¦s = minecraft:dried_kelp
 
 # Groups of items for useful reference
 categories:
-    any cod [fillet]¦s = raw cod, cooked cod
-    any salmon [fillet]¦s = raw salmon, cooked salmon
-    any raw fish¦es = raw cod, raw salmon, pufferfish, tropical fish
-    any cooked (fish¦es|fish fillet¦s) = cooked cod, cooked salmon
-    any fish¦es = any raw fish, any cooked fish
-    
-    any golden apple = normal golden apple, enchanted golden apple
-    [any] (soup|stew)¦s = beetroot soup, mushroom stew, rabbit stew
-    [any] root vegetable¦s = beetroot, carrot, potato
-    any poato¦es = potato, baked potato
-    [any] fruit¦s = apple, chorus fruit, melon slice, any golden apple
-    
-    [any] raw meat¦s = raw beef, raw chicken, raw mutton, raw porkchop, raw rabbit
-    [any] cooked meat¦s = steak, cooked chicken, cooked mutton, cooked porkchop, cooked rabbit
-    [any] meat¦s = any raw meat, any cooked meat
-    [any] monster (food|meat¦s) = rotten flesh, spider eye
-    
-    [any] dessert¦s = cookie, cake, pumpkin pie
-    [any] cooked food¦s = baked potato, any cooked meat, any cooked fish
+	any cod [fillet]¦s = raw cod, cooked cod
+	any salmon [fillet]¦s = raw salmon, cooked salmon
+	any raw fish¦es = raw cod, raw salmon, pufferfish, tropical fish
+	any cooked (fish¦es|fish fillet¦s) = cooked cod, cooked salmon
+	any fish¦es = any raw fish, any cooked fish
+	
+	any golden apple = normal golden apple, enchanted golden apple
+	[any] (soup|stew)¦s = beetroot soup, mushroom stew, rabbit stew
+	[any] root vegetable¦s = beetroot, carrot, potato
+	any potato¦es = potato, baked potato
+	[any] fruit¦s = apple, chorus fruit, melon slice, any golden apple
+	
+	[any] raw meat¦s = raw beef, raw chicken, raw mutton, raw porkchop, raw rabbit
+	[any] cooked meat¦s = steak, cooked chicken, cooked mutton, cooked porkchop, cooked rabbit
+	[any] meat¦s = any raw meat, any cooked meat
+	[any] monster (food|meat¦s) = rotten flesh, spider eye
+	
+	[any] dessert¦s = cookie, cake, pumpkin pie
+	[any] cooked food¦s = baked potato, any cooked meat, any cooked fish
 
 # All foods before
 old all foods:
-    minecraft version = 1.12.2 or older
-    [any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato
+	minecraft version = 1.12.2 or older
+	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato
 
 all foods after update aquatic:
-    minecraft version = 1.13 or newer 
-    [any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp
+	minecraft version = 1.13 or newer 
+	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp


### PR DESCRIPTION
#### Combat 
When I did the horse armor and barding, I feel I did it wrong.
I put  "iron horse armor or iron horse barding" when it should have been "iron horse armor or iron barding"
Example (should be):
```iron (horse armo[u]r|barding)```
instead of (what I first put):
```iron horse (armo[u]r|barding)```
Tiny change, but more grammatically correct plus matches the actual minecraft ID's better
"iron_barding" and "iron_horse_armor"

#### FoodStuffs
- Fixed a spelling mistake in and potato (was spelled poato)
- Added brackets to raw chicken and rabbit to keep consistency with other raw foods
- Changed all spaces to tabs to keep consistency with other alias files, (Saw a comment from Bensku on another pull request that he prefers tabs)