### PR TITLE
Small fixes

### DIFF
--- a/building.sk
+++ b/building.sk
@@ -352,6 +352,18 @@ building blocks after flattening:
 	magma [block¦s] = minecraft:magma_block
 	red nether brick¦s = minecraft:red_nether_bricks
 
+
+
+	# Miscellaneous
+	pumpkin¦s = minecraft:pumpkin
+	(unlit|carved) pumpkin¦s = minecraft:carved_pumpkin
+	(lit pumpkin|jack(-| )o['](-| )lantern)¦s = minecraft:jack_o_lantern
+	melon [block]¦s = minecraft:melon
+	[red] brick block¦s = minecraft:bricks
+	{axis-aligned} hay [(bale|block)¦s] = minecraft:hay_block
+	[any] hay [(bale|block)¦s] = vertical hay bale, east-west hay bale, north-south hay bale
+	snow block¦s = minecraft:snow_block
+
 	# Snow layers
 	{snow depth}:
 		1 = -[layers=0]
@@ -364,16 +376,6 @@ building blocks after flattening:
 		8 = -[layers=8]
 	{snow depth} deep snow block = snow block
 	full snow block = 8 deep snow block
-
-	# Miscellaneous
-	pumpkin¦s = minecraft:pumpkin
-	(unlit|carved) pumpkin¦s = minecraft:carved_pumpkin
-	(lit pumpkin|jack(-| )o['](-| )lantern)¦s = minecraft:jack_o_lantern
-	melon [block]¦s = minecraft:melon
-	[red] brick block¦s = minecraft:bricks
-	{axis-aligned} hay [(bale|block)¦s] = minecraft:hay_block
-	[any] hay [(bale|block)¦s] = vertical hay bale, east-west hay bale, north-south hay bale
-	snow block¦s = minecraft:snow_block
 
 # Categories for items that exist in both 1.13 and before but with different ids
 categories:

--- a/redstone.sk
+++ b/redstone.sk
@@ -194,7 +194,7 @@ redstone after flattening:
 
 	# Pistons
 	{extendable}:
-		{defaut} = -
+		{defaut} = -[extended=false]
 		(unextended|retracted) = -[extended=false]
 		extended = -[extended=true]
 	{orientable} {extendable} [(normal|non-sticky)] piston¦s = minecraft:piston


### PR DESCRIPTION
- Moved the SNOW LAYERS section AFTER when snow block is created under "MISCELLANEOUS" (This shows up in the "changes" and changes to the misc section, but thats only because I moved the snow layer section)
"snow block¦s = minecraft:snow_block" Needs to load before the snow layers part
- Fixed piston, missing default state