### PR TITLE
Numerical snow layer issue

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -133,14 +133,14 @@ decoratives before flattening:
 	west[ward] facing ladder = minecraft:ladder {Damage:5}
 
 	snow layer¦s = minecraft:snow_layer
-	(1|one) thick snow layer = minecraft:snow_layer {Damage:0}
-	(2|two) thick snow layer = minecraft:snow_layer {Damage:1}
-	(3|three) thick snow layer = minecraft:snow_layer {Damage:2}
-	(4|four) thick snow layer = minecraft:snow_layer {Damage:3}
-	(5|five) thick snow layer = minecraft:snow_layer {Damage:4}
-	(6|six) thick snow layer = minecraft:snow_layer {Damage:5}
-	(7|seven) thick snow layer = minecraft:snow_layer {Damage:6}
-	(8|eight) thick snow layer = minecraft:snow_layer {Damage:7}
+	(one) thick snow layer = minecraft:snow_layer {Damage:0}
+	(two) thick snow layer = minecraft:snow_layer {Damage:1}
+	(three) thick snow layer = minecraft:snow_layer {Damage:2}
+	(four) thick snow layer = minecraft:snow_layer {Damage:3}
+	(five) thick snow layer = minecraft:snow_layer {Damage:4}
+	(six) thick snow layer = minecraft:snow_layer {Damage:5}
+	(seven) thick snow layer = minecraft:snow_layer {Damage:6}
+	(eight) thick snow layer = minecraft:snow_layer {Damage:7}
 
 	iron bar¦s = minecraft:iron_bars
 	[plain] glass pane¦s = minecraft:glass_pane
@@ -291,14 +291,14 @@ decoratives after flattening:
 	[any] furnace¦s = lit furnace, unlit furnace
 
 	snow layer¦s = minecraft:snow
-	(1|one) thick snow layer = minecraft:snow[layers=1]
-	(2|two) thick snow layer = minecraft:snow[layers=2]
-	(3|three) thick snow layer = minecraft:snow[layers=3]
-	(4|four) thick snow layer = minecraft:snow[layers=4]
-	(5|five) thick snow layer = minecraft:snow[layers=5]
-	(6|six) thick snow layer = minecraft:snow[layers=6]
-	(7|seven) thick snow layer = minecraft:snow[layers=7]
-	(8|eight) thick snow layer = minecraft:snow[layers=8]
+	(one) thick snow layer = minecraft:snow[layers=1]
+	(two) thick snow layer = minecraft:snow[layers=2]
+	(three) thick snow layer = minecraft:snow[layers=3]
+	(four) thick snow layer = minecraft:snow[layers=4]
+	(five) thick snow layer = minecraft:snow[layers=5]
+	(six) thick snow layer = minecraft:snow[layers=6]
+	(seven) thick snow layer = minecraft:snow[layers=7]
+	(eight) thick snow layer = minecraft:snow[layers=8]
 
 	{waterloggable} iron bar¦s = minecraft:iron_bars
 	{waterloggable} [plain] glass pane¦s = minecraft:glass_pane

--- a/decoration.sk
+++ b/decoration.sk
@@ -133,14 +133,14 @@ decoratives before flattening:
 	west[ward] facing ladder = minecraft:ladder {Damage:5}
 
 	snow layer¦s = minecraft:snow_layer
-	(one) thick snow layer = minecraft:snow_layer {Damage:0}
-	(two) thick snow layer = minecraft:snow_layer {Damage:1}
-	(three) thick snow layer = minecraft:snow_layer {Damage:2}
-	(four) thick snow layer = minecraft:snow_layer {Damage:3}
-	(five) thick snow layer = minecraft:snow_layer {Damage:4}
-	(six) thick snow layer = minecraft:snow_layer {Damage:5}
-	(seven) thick snow layer = minecraft:snow_layer {Damage:6}
-	(eight) thick snow layer = minecraft:snow_layer {Damage:7}
+	one thick snow layer = minecraft:snow_layer {Damage:0}
+	two thick snow layer = minecraft:snow_layer {Damage:1}
+	three thick snow layer = minecraft:snow_layer {Damage:2}
+	four thick snow layer = minecraft:snow_layer {Damage:3}
+	five thick snow layer = minecraft:snow_layer {Damage:4}
+	six thick snow layer = minecraft:snow_layer {Damage:5}
+	seven thick snow layer = minecraft:snow_layer {Damage:6}
+	eight thick snow layer = minecraft:snow_layer {Damage:7}
 
 	iron bar¦s = minecraft:iron_bars
 	[plain] glass pane¦s = minecraft:glass_pane
@@ -291,14 +291,14 @@ decoratives after flattening:
 	[any] furnace¦s = lit furnace, unlit furnace
 
 	snow layer¦s = minecraft:snow
-	(one) thick snow layer = minecraft:snow[layers=1]
-	(two) thick snow layer = minecraft:snow[layers=2]
-	(three) thick snow layer = minecraft:snow[layers=3]
-	(four) thick snow layer = minecraft:snow[layers=4]
-	(five) thick snow layer = minecraft:snow[layers=5]
-	(six) thick snow layer = minecraft:snow[layers=6]
-	(seven) thick snow layer = minecraft:snow[layers=7]
-	(eight) thick snow layer = minecraft:snow[layers=8]
+	one thick snow layer = minecraft:snow[layers=1]
+	two thick snow layer = minecraft:snow[layers=2]
+	three thick snow layer = minecraft:snow[layers=3]
+	four thick snow layer = minecraft:snow[layers=4]
+	five thick snow layer = minecraft:snow[layers=5]
+	six thick snow layer = minecraft:snow[layers=6]
+	seven thick snow layer = minecraft:snow[layers=7]
+	eight thick snow layer = minecraft:snow[layers=8]
 
 	{waterloggable} iron bar¦s = minecraft:iron_bars
 	{waterloggable} [plain] glass pane¦s = minecraft:glass_pane


### PR DESCRIPTION
Removed the numerical values for snow layers
Using things like "1 thick snow layer" wasn't parsing the number as part of the snow layer but rather as the amount of items

Also note... I went thru the rest of the alias files. A bunch of numbers that did not need to be removed as the number is WITHIN the alias not at the beginning .... example "level 1 something" .... I did some testing, and because the number is inside the alias it seems to work properly.