### PR TITLE
Fix comparison with normal golden apple failing

### DIFF
--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -46,7 +46,7 @@ foods before flattening:
 	cooked salmon [fillet]¦s = minecraft:cooked_fish {Damage:1}
 	any raw fish¦es = raw cod, raw salmon, pufferfish, clownfish
 
-	[normal] golden apple = minecraft:golden_apple {Damage:0}
+	[normal] golden apple = minecraft:golden_apple
 	(enchanted golden|notch) apple = minecraft:golden_apple {Damage:1}
 	
 	melon slice¦s = minecraft:melon


### PR DESCRIPTION
Sometimes, comparing an item in a slot or other stuff like that with a normal golden apple fails because of the `{Damage:0}` attached to it. Note that many other "parent" items with data value 0 don't have it. Removing it fixes comparison problems.