### PR TITLE
Make beacons not have NBT tags by default

### DIFF
--- a/misc.sk
+++ b/misc.sk
@@ -53,7 +53,7 @@ new items:
 
 valuables:
 	{beacon levels}:
-		{default} = - {Levels:0}
+		{default} = -
 		(level (0|one)|unleveled) = - {Levels:0}
 		(level (1|one)) = - {Levels:1}
 		(level (2|two)) = - {Levels:2}


### PR DESCRIPTION
Make beacons not have NBT tags by default, since that will cause comparison issues with normal vanilla beacons. Instead, if the user wishes to have a beacon have a specific level embedded into its NBT, they will now have to explicitly state the beacon's level.

Related Issues: https://github.com/SkriptLang/Skript/issues/2395, https://github.com/SkriptLang/Skript/issues/2459