### PR TITLE
Legacy items fix

### DIFF
--- a/building.sk
+++ b/building.sk
@@ -169,6 +169,16 @@ old blocks before flattening:
 	(upside-down|top) [nether] quartz slab = minecraft:stone_slab {Damage:15}
 	(upside-down|top) red sandstone slab = minecraft:stone_slab2 {Damage:8}
 
+	double stone slab = minecraft:double_stone_slab {Damage:0}
+	double sandstone slab = minecraft:double_stone_slab {Damage:1}
+	double (petrified|stone) oak [wood[en]] slab = minecraft:double_stone_slab {Damage:2}
+	double cobble[stone] slab = minecraft:double_stone_slab {Damage:3}
+	double brick slab = minecraft:double_stone_slab {Damage:4}
+	double stone[ ]brick slab = minecraft:double_stone_slab {Damage:5}
+	double nether brick slab = minecraft:double_stone_slab {Damage:6}
+	double [nether] quartz slab = minecraft:double_stone_slab {Damage:7}
+	double red sandstone slab = minecraft:double_stone_slab2 {Damage:0}
+
 	# Wood slabs
 	[bottom] {old wood type} slab = minecraft:wooden_slab
 
@@ -178,6 +188,13 @@ old blocks before flattening:
 	(upside-down|top) jungle [wood[en]] slab = minecraft:wooden_slab {Damage:11}
 	(upside-down|top) acacia [wood[en]] slab = minecraft:wooden_slab {Damage:12}
 	(upside-down|top) dark oak [wood[en]] slab = minecraft:wooden_slab {Damage:13}
+
+	double oak [wood[en]] slab = minecraft:double_wooden_slab {Damage:0}
+	double spruce [wood[en]] slab = minecraft:double_wooden_slab {Damage:1}
+	double birch [wood[en]] slab = minecraft:double_wooden_slab {Damage:2}
+	double jungle [wood[en]] slab = minecraft:double_wooden_slab {Damage:3}
+	double acacia [wood[en]] slab = minecraft:double_wooden_slab {Damage:4}
+	double dark oak [wood[en]] slab = minecraft:double_wooden_slab {Damage:5}
 
 	any wood[en] slab = oak slab, spruce slab, birch slab, jungle slab, acacia slab, dark oak slab
 	any slab = any wooden slab, stone slab, sandstone slab, petrified oak slab, cobblestone slab, brick slab, stone brick slab, nether brick slab, quartz slab, red sandstone slab

--- a/decoration.sk
+++ b/decoration.sk
@@ -11,7 +11,8 @@ unchanged decoratives:
 	[huge] red mushroom block¦s = minecraft:red_mushroom_block
 	vine¦s = minecraft:vine
 	enchant(ment|ing) table¦s = minecraft:enchanting_table
-	[empty] flower pot¦s = minecraft:flower_pot
+	[empty] flower pot¦s = minecraft:flower_pot_block
+	[empty] flower pot item¦s = minecraft:flower_pot
 	painting [item]¦s = minecraft:painting[relatedEntity=painting]
 	item frame [item]¦s = minecraft:item_frame[relatedEntity=item frame]
 	armor stand [item]¦s = minecraft:armor_stand[relatedEntity=armor stand]

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -7,7 +7,6 @@ unchanged foods:
 	beetroot¦s = minecraft:beetroot
 	beetroot (stew|soup)¦s = minecraft:beetroot_soup
 	[loa(f|ves) of] bread = minecraft:bread
-	cake¦s = minecraft:cake
 	carrot¦s = minecraft:carrot
 	chorus fruit¦s = minecraft:chorus_fruit
 	(cooked beef|steak¦s) = minecraft:cooked_beef
@@ -51,6 +50,9 @@ foods before flattening:
 	
 	melon slice¦s = minecraft:melon
 
+	cake¦s = minecraft:cake_block
+	cake item¦s = minecraft:cake
+
 # Foods whose IDs were changed as part of the ID flattening in 1.13.
 foods after flattening:
 	minecraft version = 1.13 or newer
@@ -67,6 +69,8 @@ foods after flattening:
 	
 	melon slice¦s = minecraft:melon_slice
 	dried kelp¦s = minecraft:dried_kelp
+
+	cake¦s = minecraft:cake
 
 # Groups of items for useful reference
 common categories:
@@ -85,15 +89,15 @@ common categories:
 	[any] cooked meat¦s = steak, cooked chicken, cooked mutton, cooked porkchop, cooked rabbit
 	[any] meat¦s = any raw meat, any cooked meat
 	[any] monster (food|meat¦s) = rotten flesh, spider eye
-	
-	[any] dessert¦s = cookie, cake, pumpkin pie
 	[any] cooked food¦s = baked potato, any cooked meat, any cooked fish
 
 # All foods before
 old food categories:
 	minecraft version = 1.12.2 or older
+	[any] dessert¦s = cookie, cake item, pumpkin pie
 	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato
 
 food categories after update aquatic:
-	minecraft version = 1.13 or newer 
+	minecraft version = 1.13 or newer
+	[any] dessert¦s = cookie, cake, pumpkin pie
 	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp

--- a/misc.sk
+++ b/misc.sk
@@ -22,7 +22,8 @@ exploration update 2:
 old items:
 	minecraft version = 1.12.2 or older
 	charcoal = minecraft:coal {Damage:1}
-	sugar cane¦s = minecraft:reeds
+	sugar cane item¦s = minecraft:reeds
+	sugar cane¦s = minecraft:sugar_cane_block
 	popped chorus fruit¦s = minecraft:chorus_fruit_popped
 	nether brick item¦s = minecraft:netherbrick
 
@@ -79,7 +80,6 @@ random items:
 	sugar = minecraft:sugar
 	ender pearl¦s = minecraft:ender_pearl[relatedEntity=ender pearl]
 	blaze rod¦s = minecraft:blaze_rod
-	nether wart item¦s = minecraft:nether_wart
 	(ender eye¦s|eye[s] of ender) = minecraft:ender_eye
 	(bottle[s] o' enchanting|xp bottle¦s|experience bottle¦s) = minecraft:experience_bottle[relatedEntity=xp bottle]
 	fire charge¦s = minecraft:fire_charge
@@ -91,6 +91,16 @@ random items:
 	prismarine crystal¦s = minecraft:prismarine_crystals
 	rabbit hide¦s = minecraft:rabbit_hide
 	enchanted book¦s = minecraft:enchanted_book
+
+pre-flattening random items:
+	minecraft version = 1.12.2 or older
+	nether wart item¦s = minecraft:nether_wart
+	nether wart [plant]¦s = minecraft:nether_warts
+
+post-flattening random items:
+	minecraft version = 1.13 or newer
+	nether wart [item]¦s = minecraft:nether_wart
+
 
 books:
 	book¦s = minecraft:book

--- a/other.sk
+++ b/other.sk
@@ -62,7 +62,7 @@ unlisted before flattening:
 		(ripe|fully grown|stage (8|eight)) = - {Damage:7}
 	{crop growth stage} potato plant¦s = minecraft:potatoes
 	{crop growth stage} carrot plant¦s = minecraft:carrots
-	{crop growth stage} wheat plant¦s = minecraft:wheat
+	{crop growth stage} wheat plant¦s = minecraft:wheat_plant
 	{crop growth stage} pumpkin stem = minecraft:pumpkin_stem
 	{crop growth stage} melon stem = minecraft:melon_stem
 	{beetroot growth stage}:
@@ -208,5 +208,7 @@ updated fluids:
 	{fluid state} lava = minecraft:lava
 old fluids:
 	minecraft version = 1.12.2 or older
+	flowing water = minecraft:flowing_water
+	flowing lava = minecraft:flowing_lava
 	[stationary] water = minecraft:water
 	[stationary] lava = minecraft:lava

--- a/redstone.sk
+++ b/redstone.sk
@@ -86,14 +86,27 @@ redstone before flattening:
 		left-hinged powered [closed] top = - {Damage:10}
 		right-hinged powered [closed] top = - {Damage:11}
 
-	{door state} oak [wood] door¦s = minecraft:wooden_door
-	{door state} iron door¦s = minecraft:iron_door
-	{door state} spruce [wood] door¦s = minecraft:spruce_door
-	{door state} birch [wood] door¦s = minecraft:birch_door
-	{door state} jungle [wood] door¦s = minecraft:jungle_door
-	{door state} acacia [wood] door¦s = minecraft:acacia_door
-	{door state} dark oak [wood] door¦s = minecraft:dark_oak_door
+	# Door blocks
+	{door state} oak [wood] door¦s = minecraft:wooden_door_block
+	{door state} iron door¦s = minecraft:iron_door_block
+	{door state} spruce [wood] door¦s = minecraft:spruce_door_block
+	{door state} birch [wood] door¦s = minecraft:birch_door_block
+	{door state} jungle [wood] door¦s = minecraft:jungle_door_block
+	{door state} acacia [wood] door¦s = minecraft:acacia_door_block
+	{door state} dark oak [wood] door¦s = minecraft:dark_oak_door_block
+
+	# Door items
+	oak [wood] door item¦s = minecraft:wooden_door
+	iron door item¦s = minecraft:iron_door
+	spruce [wood] door item¦s = minecraft:spruce_door
+	birch [wood] door item¦s = minecraft:birch_door
+	jungle [wood] door item¦s = minecraft:jungle_door
+	acacia [wood] door item¦s = minecraft:acacia_door
+	dark oak [wood] door item¦s = minecraft:dark_oak_door
+
+	[any] wood[en] door item¦s = oak door item, spruce door item, birch door item, jungle door item, acacia door item, dark oak door item
 	[any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door
+	[any] door item¦s = iron door item, any wood door item
 	[any] door¦s = iron door, any wood door
 
 	# Redstone torches


### PR DESCRIPTION
### Description
There is a big issue in Skript with Minecraft versions 1.12.2 and below, where certain aliases are not working, ie:
- Wheat plants
- Nether wart plants
- Doors
- Double slabs

You are not able to set these items, and if you try to return the item (ie: `target block of player`) it returns a Bukkit enum (ex: if the target block is a wheat plant it returns `CROPS`)

This PR will go along with a fix in Skript, see [**PR here**](https://github.com/SkriptLang/Skript/pull/2593), and should only be accepted/merged once that PR is merged.

### Special Note:
I wanted to jump the gun before someone asks about this change:
```vb
old fluids:
 	minecraft version = 1.12.2 or older
 	flowing water = minecraft:flowing_water
 	flowing lava = minecraft:flowing_lava
```
"But you can't place flowing water", well, you actually can, the water on the left is `water` and the water on the right is `flowing water`
<img width="966" alt="Screen Shot 2019-10-24 at 3 54 27 PM" src="https://user-images.githubusercontent.com/20008482/67532591-a881cd00-f67b-11e9-99f8-3d7b59d5bf47.png">
