### PR TITLE
Feature/buzzy bee update

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -581,3 +581,20 @@ directionals after flattening:
 glazed terracotta group:
 	minecraft version = 1.12 or newer
 	any glazed terracotta = white glazed terracotta, orange glazed terracotta, magenta glazed terracotta, light blue glazed terracotta, yellow glazed terracotta, lime glazed terracotta, pink glazed terracotta, dark gray glazed terracotta, light gray glazed terracotta, cyan glazed terracotta, purple glazed terracotta, blue glazed terracotta, brown glazed terracotta, dark green glazed terracotta, red glazed terracotta, black glazed terracotta
+
+buzzy bee update:
+	minecraft version = 1.15 or newer
+	{honey level}:
+		{default} = -
+		(empty|level 0) = -[honey_level=0]
+		level 1 = -[honey_level=1]
+		level 2 = -[honey_level=2]
+		level 3 = -[honey_level=3]
+		level 4 = -[honey_level=4]
+		(full|filled|level 5) = -[honey_level=5]
+
+	{directional} {honey level} beehive¦s = minecraft:beehive
+	{directional} {honey level} bee nest¦s = minecraft:bee_nest
+
+	honey block¦s = minecraft:honey_block
+	honeycomb block¦s = minecraft:honeycomb_block

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -34,6 +34,10 @@ village and pillage update foods:
 	dried kelp = minecraft:dried_kelp
 	sweet berr(y|ies) = minecraft:sweet_berries
 
+buzzy bee update update foods:
+	minecraft version = 1.15 or newer
+	honey bottle¦s = minecraft:honey_bottle
+
 # Before the flattening in 1.13, some foods used data values.
 foods before flattening:
 	minecraft version = 1.12.2 or older
@@ -80,16 +84,20 @@ common categories:
 	any fish¦es = any raw fish, any cooked fish
 	
 	any golden apple = normal golden apple, enchanted golden apple
+	any apple = any golden apple, apple
 	[any] (soup|stew)¦s = beetroot soup, mushroom stew, rabbit stew
 	[any] root vegetable¦s = beetroot, carrot, potato
 	any potato¦es = potato, baked potato
-	[any] fruit¦s = apple, chorus fruit, melon slice, any golden apple
+	[any] fruit¦s = any apple, chorus fruit, melon slice
 	
 	[any] raw meat¦s = raw beef, raw chicken, raw mutton, raw porkchop, raw rabbit
 	[any] cooked meat¦s = steak, cooked chicken, cooked mutton, cooked porkchop, cooked rabbit
 	[any] meat¦s = any raw meat, any cooked meat
 	[any] monster (food|meat¦s) = rotten flesh, spider eye
 	[any] cooked food¦s = baked potato, any cooked meat, any cooked fish
+
+	minecraft version = 1.14 or newer
+	[any] fruit¦s = any apple, chorus fruit, melon slice, sweet berry
 
 # All foods before
 old food categories:
@@ -101,3 +109,7 @@ food categories after update aquatic:
 	minecraft version = 1.13 or newer
 	[any] dessert¦s = cookie, cake, pumpkin pie
 	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp
+
+food categories after buzzy bee update:
+	minecraft version = 1.15 or newer
+    [any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp, honey bottle

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -96,6 +96,7 @@ common categories:
 	[any] monster (food|meat¦s) = rotten flesh, spider eye
 	[any] cooked food¦s = baked potato, any cooked meat, any cooked fish
 
+village and pillage common categories:
 	minecraft version = 1.14 or newer
 	[any] fruit¦s = any apple, chorus fruit, melon slice, sweet berry
 

--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -112,4 +112,4 @@ food categories after update aquatic:
 
 food categories after buzzy bee update:
 	minecraft version = 1.15 or newer
-    [any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp, honey bottle
+	[any] food = any fish, fruit, root vegetables, stews, meats, monster meats, desserts, bread, baked potato, poisonous potato, dried kelp, honey bottle

--- a/misc.sk
+++ b/misc.sk
@@ -314,6 +314,11 @@ village and pillage spawn eggs:
 	(panda [spawn] egg|spawn panda)¦s = minecraft:panda_spawn_egg
 	[any] spawn egg¦s = spawn bat, spawn blaze, spawn cave spider, spawn chicken, spawn cod, spawn cow, spawn creeper, spawn dolphin, spawn donkey, spawn drowned, spawn elder guardian, spawn enderman, spawn endermite, spawn evoker, spawn ghast, spawn guardian, spawn horse, spawn husk, spawn llama, spawn magma cube, spawn mooshroom, spawn mule, spawn ocelot, spawn parrot, spawn phantom, spawn pig, spawn polar bear, spawn pufferfish, spawn rabbit, spawn salmon, spawn sheep, spawn shulker, spawn silverfish, spawn skeleton, spawn skeleton horse, spawn slime, spawn spider, spawn squid, spawn stray, spawn tropical fish, spawn turtle, spawn vex, spawn villager, spawn vindicator, spawn witch, spawn wither skeleton, spawn wolf, spawn zombie, spawn zombie horse, spawn zombie pigman, spawn zombie villager, spawn pillager, spawn ravager, spawn wandering trader, spawn trader llama, spawn cat, spawn fox, spawn panda
 
+buzzy bee spawn eggs:
+	minecraft version = 1.15 or newer
+	(bee [spawn] egg|spawn bee)¦s = minecraft:bee_spawn_egg
+	[any] spawn egg¦s = spawn bat, spawn blaze, spawn cave spider, spawn chicken, spawn cod, spawn cow, spawn creeper, spawn dolphin, spawn donkey, spawn drowned, spawn elder guardian, spawn enderman, spawn endermite, spawn evoker, spawn ghast, spawn guardian, spawn horse, spawn husk, spawn llama, spawn magma cube, spawn mooshroom, spawn mule, spawn ocelot, spawn parrot, spawn phantom, spawn pig, spawn polar bear, spawn pufferfish, spawn rabbit, spawn salmon, spawn sheep, spawn shulker, spawn silverfish, spawn skeleton, spawn skeleton horse, spawn slime, spawn spider, spawn squid, spawn stray, spawn tropical fish, spawn turtle, spawn vex, spawn villager, spawn vindicator, spawn witch, spawn wither skeleton, spawn wolf, spawn zombie, spawn zombie horse, spawn zombie pigman, spawn zombie villager, spawn pillager, spawn ravager, spawn wandering trader, spawn trader llama, spawn cat, spawn fox, spawn panda, spawn bee
+
 # These are for mobs that have existed since at least 1.8 and these IDs remained valid up through 1.12
 spawn eggs before flattening:
 	minecraft version = 1.12.2 or older
@@ -440,3 +445,7 @@ village and pillage update:
 	(mojang|thing) banner pattern¦s = minecraft:mojang_banner_pattern
 	globe banner pattern¦s = minecraft:globe_banner_pattern
 	[any] banner pattern¦s = flower charge banner pattern, creeper charge banner pattern, skull charge banner pattern, thing banner pattern, globe banner pattern
+
+buzzy bee update:
+	minecraft version = 1.15 or newer
+	honeycomb¦s = minecraft:honeycomb


### PR DESCRIPTION
This PR adds new bee related items/blocks for the upcoming Minecraft 1.15 Buzzy Bee update

I also refactored some food categories a bit to include sweet berries, and create an `any apple` food category.