### PR TITLE
Fix issue with redstone.sk

### DIFF
--- a/redstone.sk
+++ b/redstone.sk
@@ -258,7 +258,8 @@ nether update:
 	[any] wood[en] door¦s = oak door, spruce door, birch door, jungle door, acacia door, dark oak door, crimson door, warped door
 	[any] wood[en] trapdoor¦s = oak trapdoor, spruce trapdoor, birch trapdoor, jungle trapdoor, acacia trapdoor, dark oak trapdoor, crimson trapdoor, warped trapdoor
 
-global:
+global post flattening:
+	minecraft version = 1.13 or newer
 	[any] door¦s = iron door, any wooden door
 	[any] button¦s = stone button, wood button
 	[any] trapdoor¦s = iron trapdoor, any wooden trapdoor


### PR DESCRIPTION
This PR fixes SkriptLang/Skript#3107. The global aliases don't *really* need to be registered on versions before 1.13.