### PR TITLE
Fix missing "all signs" for 1.16 (to include warped/crimson signs)

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -643,3 +643,7 @@ nether update:
 
 	{lantern hanging} soul lantern¦s = minecraft:soul_lantern
 	any lantern = lantern, soul lantern
+
+	[any] wall sign¦s = any wall sign, crimson wall sign, warped wall sign
+	[any] floor sign¦s = any floor sign, crimson floor sign, warped floor sign
+	[any] sign¦s = any wall sign, any floor sign


### PR DESCRIPTION
This PR aims to add in "all signs" for 1.16+
(Something I must have forgotten to do in the update)

Issue: https://github.com/SkriptLang/Skript/issues/3272