### PR TITLE
decoration - add alias for any furnace in 1.14+

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -365,6 +365,7 @@ village and pillage decoratives:
 	{directional} {lightable} blast furnace¦s = minecraft:blast_furnace
 	{directional} stone[ ]cutter¦s = minecraft:stonecutter
 	cartography table¦s = minecraft:cartography_table
+	any furnace = any furnace, smoker, blast furnace
 
 	# Whether the grindstone is on the floor, wall, or ceiling.
 	{grindstone face}:


### PR DESCRIPTION
This PR adds an alias "any furnace" for 1.14+ to cover furnaces, blast furnaces and smokers.

This is in reference to issue https://github.com/SkriptLang/Skript/issues/3286

The issue stems from this:
```java
static final ItemType anyFurnace = Aliases.javaItemType("any furnace");
```
The class is looking for "any furnace" for furnace inventory slots