### PR TITLE
Fix chorus fruit double

### DIFF
--- a/misc.sk
+++ b/misc.sk
@@ -135,7 +135,6 @@ plants:
 	any seed¦s = pumpkin seeds, melon seeds, wheat seeds
 
 	wheat [item¦s] = minecraft:wheat
-	chorus fruit¦s = minecraft:chorus_fruit
 
 unchanged buckets:
 	[empty] bucket¦s = minecraft:bucket


### PR DESCRIPTION
Chorus fruit is doubled in the aliases, causing SkriptLang/Skript#2110