### PR TITLE
Add 1.19 features

### DIFF
--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -300,4 +300,4 @@ wild-update woods:
 		dark oak [wood] = minecraft:dark_oak_-
 		crimson = minecraft:crimson_-
 		warped = minecraft:warped_-
-		mangrove = minecraft:mangrove_-
+		mangrove [wood] = minecraft:mangrove_-

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -286,3 +286,22 @@ nether-update woods:
 	{nether block}:
 		crimson = minecraft:crimson_-
 		warped = minecraft:warped_-
+
+wild-update woods:
+	minecraft version = 1.19 or newer
+
+    # For wood-based blocks that are defined with the wood type at the start of the alias.
+	{wood type}:
+		oak [wood] = minecraft:oak_-
+		spruce [wood] = minecraft:spruce_-
+		birch [wood] = minecraft:birch_-
+		jungle [wood] = minecraft:jungle_-
+		acacia [wood] = minecraft:acacia_-
+		dark oak [wood] = minecraft:dark_oak_-
+		crimson = minecraft:crimson_-
+		warped = minecraft:warped_-
+		mangrove = minecraft:mangrove_-
+
+	{nether block}:
+		crimson = minecraft:crimson_-
+		warped = minecraft:warped_-

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -301,7 +301,3 @@ wild-update woods:
 		crimson = minecraft:crimson_-
 		warped = minecraft:warped_-
 		mangrove = minecraft:mangrove_-
-
-	{nether block}:
-		crimson = minecraft:crimson_-
-		warped = minecraft:warped_-

--- a/building.sk
+++ b/building.sk
@@ -776,27 +776,24 @@ the wild update:
 	packed mud = minecraft:packed_mud
 	mud bricks = minecraft:mud_bricks
 
-	{waterloggable} {slab} mud brick slab|s = minecraft:mud_brick_slab
+	{waterloggable} {slab} mud brick slab¦s = minecraft:mud_brick_slab
 	[any] slab¦s = any slab, mud brick slab
 
 	reinforced deepslate = minecraft:reinforced_deepslate
 
 	# Sculk
-	sculk|s = minecraft:sculk
-
-	{sculk}:
-		sculk = minecraft:sculk_-
+	sculk¦s = minecraft:sculk
 	
-	{sculk} catalyst = -catalyst
+	sculk catalyst = minecraft:sculk_catalyst
 
 	{summonable}:
 		{default} = -
-		summonable = -[can_summon=true]
-		(nonsummable|nowarden) = -[can_summon=false]
+		(summonable|active) = -[can_summon=true]
+		(non-summable|no-warden|activated) = -[can_summon=false]
 	
 	{shriekable}:
 		{default} = -
 		shrieking = -[shrieking=true]
-		quiet = -[shrieking=false]
+		(quiet|non-shrieking) = -[shrieking=false]
 	
 	{waterloggable} {summonable} {shriekable} {sculk} shrieker = -shrieker

--- a/building.sk
+++ b/building.sk
@@ -779,7 +779,7 @@ the wild update:
 	{waterloggable} {slab} mud brick slab|s = minecraft:mud_brick_slab
 	[any] slab¦s = any slab, mud brick slab
 
-	reinforced deepalate|s = minecraft:reinforced_deepslate
+	reinforced deepslate = minecraft:reinforced_deepslate
 
 	# Sculk
 	sculk|s = minecraft:sculk

--- a/building.sk
+++ b/building.sk
@@ -760,3 +760,43 @@ caves and cliffs update part 1:
 	[any] stone ore = any stone ore, copper ore
 	[any] deepslate ore = deepslate coal ore, deepslate iron ore, deepslate copper ore, deepslate gold ore, deepslate redstone ore, deepslate emerald ore, deepslate lapis ore, deepslate diamond ore
 	[any] ore = any stone ore, any nether ore, any deepslate ore
+
+the wild update:
+	minecraft version = 1.19 or newer
+
+	# froglights
+	orche froglight|s = minecraft:orche_froglight
+	pearlescent froglisht|s = minecraft:pearlescent_froglight
+	verdant froglight|s = minecraft:verdant_froglight
+	any froglight|s = orghe froglight, pearlescent froglight, verdant froglight
+
+	# muds
+	mud = minecraft:mud
+	muddy mangrove roots = minecraft:muddy_mangrove_roots
+	packed mud = minecraft:packed_mud
+	mud bricks = minecraft:mud_bricks
+
+	{waterloggable} {slab} mud brick slab|s = minecraft:mud_brick_slab
+	[any] slab¦s = any slab, mud brick slab
+
+	reinforced deepalate|s = minecraft:reinforced_deepslate
+
+	# Sculk
+	sculk|s = minecraft:sculk
+
+	{sculk}:
+		sculk = minecraft:sculk_-
+	
+	{sculk} catalyst = -catalyst
+
+	{summonable}:
+		{default} = -
+		summonable = -[can_summon=true]
+		(nonsummable|nowarden) = -[can_summon=false]
+	
+	{shriekable}:
+		{default} = -
+		shrieking = -[shrieking=true]
+		quiet = -[shrieking=false]
+	
+	{waterloggable} {summonable} {shriekable} {sculk} shrieker = -shrieker

--- a/building.sk
+++ b/building.sk
@@ -779,6 +779,7 @@ the wild update:
 	{waterloggable} {slab} mud brick slab¦s = minecraft:mud_brick_slab
 	[any] slab¦s = any slab, mud brick slab
 
+	# other build blocks
 	reinforced deepslate = minecraft:reinforced_deepslate
 
 	# Sculk

--- a/building.sk
+++ b/building.sk
@@ -782,7 +782,7 @@ the wild update:
 	reinforced deepslate = minecraft:reinforced_deepslate
 
 	# Sculk
-	sculk¦s = minecraft:sculk
+	sculk [block¦s] = minecraft:sculk
 	
 	sculk catalyst¦s = minecraft:sculk_catalyst
 
@@ -796,4 +796,4 @@ the wild update:
 		shrieking = -[shrieking=true]
 		(quiet|non-shrieking) = -[shrieking=false]
 	
-	{waterloggable} {summonable} {shriekable} {sculk} shrieker = -shrieker
+	{waterloggable} {summonable} {shriekable} shrieker = minecraft:sculk_shrieker

--- a/building.sk
+++ b/building.sk
@@ -768,7 +768,7 @@ the wild update:
 	ochre froglight¦s = minecraft:ochre_froglight
 	pearlescent froglight¦s = minecraft:pearlescent_froglight
 	verdant froglight¦s = minecraft:verdant_froglight
-	any froglight¦s = ochre froglight, pearlescent froglight, verdant froglight
+	[any] froglight¦s = ochre froglight, pearlescent froglight, verdant froglight
 
 	# muds
 	mud = minecraft:mud

--- a/building.sk
+++ b/building.sk
@@ -784,7 +784,7 @@ the wild update:
 	# Sculk
 	sculk¦s = minecraft:sculk
 	
-	sculk catalyst = minecraft:sculk_catalyst
+	sculk catalyst¦s = minecraft:sculk_catalyst
 
 	{summonable}:
 		{default} = -

--- a/building.sk
+++ b/building.sk
@@ -765,10 +765,10 @@ the wild update:
 	minecraft version = 1.19 or newer
 
 	# froglights
-	orche froglight|s = minecraft:orche_froglight
-	pearlescent froglisht|s = minecraft:pearlescent_froglight
-	verdant froglight|s = minecraft:verdant_froglight
-	any froglight|s = orghe froglight, pearlescent froglight, verdant froglight
+	ochre froglight¦s = minecraft:ochre_froglight
+	pearlescent froglight¦s = minecraft:pearlescent_froglight
+	verdant froglight¦s = minecraft:verdant_froglight
+	any froglight¦s = ochre froglight, pearlescent froglight, verdant froglight
 
 	# muds
 	mud = minecraft:mud

--- a/decoration.sk
+++ b/decoration.sk
@@ -742,7 +742,7 @@ the wild update:
 	# mangrove
 	{waterloggable} mangrove (propagule|sapling)¦s = minecraft:mangrove_propagule
 	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
-    (any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
+   (any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
 	# leaves
 	{decayable}:

--- a/decoration.sk
+++ b/decoration.sk
@@ -745,13 +745,9 @@ the wild update:
    (any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
 	# leaves
-	{decayable}:
-		{default} = -
-		decayable = -[persistent=false]
-		(persistent|permanent) = -[persistent=true]
 	{mangrove leaves}
     	mangrove = mangrove_-
-	{waterloggable} {decayable} {mangrove leaves} lea(f|ves) = -leaves
+	{waterloggable} {mangrove leaves} lea(f|ves) = -leaves
 	[any] lea(f|ves) = any leaves, mangrove leaves
 
 	{waterloggable} mud brick stairs = minecraft:mud_brick_stairs

--- a/decoration.sk
+++ b/decoration.sk
@@ -744,15 +744,14 @@ the wild update:
 	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
 	(any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
-	# leaves
-	{mangrove leaves}
-    	mangrove = mangrove_-
-	{waterloggable} {mangrove leaves} lea(f|ves) = -leaves
+	{waterloggable} {decayable} lea(f|ves) = minecraft:mangrove_leaves
 	[any] lea(f|ves) = any leaves, mangrove leaves
 
+	# mud brick stuffs
 	{waterloggable} mud brick stairs = minecraft:mud_brick_stairs
 	[any] stairs = any stairs, mud brick stairs
 
 	{waterloggable} mud brick wall¦s = minecraft:mud_brick_wall
 
+	# sculk stuffs
 	{waterloggable} {orientable} sculk vein¦s = minecraft:sculk_vein

--- a/decoration.sk
+++ b/decoration.sk
@@ -742,7 +742,7 @@ the wild update:
 	# mangrove
 	{waterloggable} mangrove (propagule|sapling)¦s = minecraft:mangrove_propagule
 	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
-   (any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
+	(any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
 	# leaves
 	{mangrove leaves}

--- a/decoration.sk
+++ b/decoration.sk
@@ -728,7 +728,32 @@ caves and cliffs update part 1:
 	{waterloggable} deepslate tile wall¦s = minecraft:deepslate_tile_wall
 	any wall[s] = any walls, cobbled deepslate wall, polished deepslate wall, deepslate brick wall, deepslate tile wall
 	
-	{waterloggable} glow lichen¦s = minecraft:glow_lichen
+	{waterloggable} {orientable} glow lichen¦s = minecraft:glow_lichen
 	glow item frame [item]¦s = minecraft:glow_item_frame[relatedEntity=glow item frame]
 	
 	(grass|dirt) path [block]¦s = minecraft:dirt_path
+
+
+the wild update:
+	minecraft version = 1.19 or newer
+
+	frogspawn|s = minecraft:frogspawn
+	
+	# mangrove
+	{waterloggable} mangrove (propagule|sapling)|s = minecraft:mangrove_propagule
+	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
+
+	# leaves
+	{decayable}:
+		{default} = -
+		decayable = -[persistent=false]
+		(persistent|permanent) = -[persistent=true]
+	{waterloggable} {decayable} ({tree type}|mangrove) lea(f|ves) = -leaves
+	[any] lea(f|ves) = oak leaves, birch leaves, jungle leaves, spruce leaves, dark oak leaves, acacia leaves, mangrove leaves
+
+	{waterloggable} mud brick stairs = minecraft:mud_brick_stairs
+	[any] stairs = any stairs, mud brick stairs
+
+	{waterloggable} mud brick wall|s = minecraft:mud_brick_wall
+
+	{waterloggable} {orientable} sculk vein|s = minecraft:sculk_vein

--- a/decoration.sk
+++ b/decoration.sk
@@ -744,6 +744,11 @@ the wild update:
 	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
 	(any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
+	{decayable}:
+		{default} = -
+		decayable = -[persistent=false]
+		(persistent|permanent) = -[persistent=true]
+	
 	{waterloggable} {decayable} lea(f|ves) = minecraft:mangrove_leaves
 	[any] lea(f|ves) = any leaves, mangrove leaves
 

--- a/decoration.sk
+++ b/decoration.sk
@@ -737,23 +737,26 @@ caves and cliffs update part 1:
 the wild update:
 	minecraft version = 1.19 or newer
 
-	frogspawn|s = minecraft:frogspawn
+	frogspawn¦s = minecraft:frogspawn
 	
 	# mangrove
-	{waterloggable} mangrove (propagule|sapling)|s = minecraft:mangrove_propagule
+	{waterloggable} mangrove (propagule|sapling)¦s = minecraft:mangrove_propagule
 	(potted|pot with) mangrove (propagule|sapling) = minecraft:potted_mangrove_propagule
+    (any flower pot|[any] potted plant) = any flower pot, potted mangrove propagule
 
 	# leaves
 	{decayable}:
 		{default} = -
 		decayable = -[persistent=false]
 		(persistent|permanent) = -[persistent=true]
-	{waterloggable} {decayable} ({tree type}|mangrove) lea(f|ves) = -leaves
-	[any] lea(f|ves) = oak leaves, birch leaves, jungle leaves, spruce leaves, dark oak leaves, acacia leaves, mangrove leaves
+	{mangrove leaves}
+    	mangrove = mangrove_-
+	{waterloggable} {decayable} {mangrove leaves} lea(f|ves) = -leaves
+	[any] lea(f|ves) = any leaves, mangrove leaves
 
 	{waterloggable} mud brick stairs = minecraft:mud_brick_stairs
 	[any] stairs = any stairs, mud brick stairs
 
-	{waterloggable} mud brick wall|s = minecraft:mud_brick_wall
+	{waterloggable} mud brick wall¦s = minecraft:mud_brick_wall
 
-	{waterloggable} {orientable} sculk vein|s = minecraft:sculk_vein
+	{waterloggable} {orientable} sculk vein¦s = minecraft:sculk_vein

--- a/misc-eggs.sk
+++ b/misc-eggs.sk
@@ -177,8 +177,8 @@ caves and cliffs update part 1:
 
 the wild update:
 	minecraft version = 1.19 or newer
-	(allay [spawn] egg|spawn allay)|s = minecraft:allay_spawn_egg
-	(frog [spawn] egg|spawn frog)|s = minecraft:frog_spawn_egg
-	(tadpole [spawn] egg|spawn tadpole)|s = minecraft:tadpole_spawn_egg
-	(warden [spawn] egg|spawn warden)|s = minecraft:warden_spawn_egg
-	[any] spawn egg|s = any spawn egg, spawn allay, spawn frog, spawn tadpole, spawn warden
+	(allay [spawn] egg|spawn allay)¦s = minecraft:allay_spawn_egg
+	(frog [spawn] egg|spawn frog)¦s = minecraft:frog_spawn_egg
+	(tadpole [spawn] egg|spawn tadpole)¦s = minecraft:tadpole_spawn_egg
+	(warden [spawn] egg|spawn warden)¦s = minecraft:warden_spawn_egg
+	[any] spawn egg¦s = any spawn egg, spawn allay, spawn frog, spawn tadpole, spawn warden

--- a/misc-eggs.sk
+++ b/misc-eggs.sk
@@ -174,3 +174,11 @@ caves and cliffs update part 1:
 	(goat [spawn] egg|spawn goat)¦s = minecraft:goat_spawn_egg
 	(glow squid [spawn] egg|spawn glow squid)¦s = minecraft:glow_squid_spawn_egg
 	[any] spawn egg¦s = any spawn egg, spawn axolotl, spawn goat, spawn glow squid
+
+the wild update:
+	minecraft version = 1.19 or newer
+	(allay [spawn] egg|spawn allay)|s = minecraft:allay_spawn_egg
+	(frog [spawn] egg|spawn frog)|s = minecraft:frog_spawn_egg
+	(tadpole [spawn] egg|spawn tadpole)|s = minecraft:tadpole_spawn_egg
+	(warden [spawn] egg|spawn warden)|s = minecraft:warden_spawn_egg
+	[any] spawn egg|s = any spawn egg, spawn allay, spawn frog, spawn tadpole, spawn warden

--- a/misc.sk
+++ b/misc.sk
@@ -337,16 +337,19 @@ caves and cliffs update part 2:
 the wild update:
 	minecraft version = 1.19 or newer
 
+	# Frog-related stuffs
 	(tadpole bucket|bucket of tadpole)¦s = minecraft:bucket_of_tadpole
 
+	# Disc 5
 	(disc|record) [5] fragment¦s = minecraft:disc_fragment_5
 	[music] (disc|record) 5 = minecraft:music_disc_5
 	[any] [music] (disc|record) = any music disc, music disc 5
 
-	# sculk-related
+	# sculk-related stuffs
 	echo shard¦s = minecraft:echo_shard
 	recovery compass¦es = minecraft:recovery_compass
 
+	# Horns
 	{horn variations}:
 		{default} = -
 		ponder = -[instrument=minecraft:ponder_goat_horn]

--- a/misc.sk
+++ b/misc.sk
@@ -337,14 +337,14 @@ caves and cliffs update part 2:
 the wild update:
 	minecraft version = 1.19 or newer
 
-	(tadpole bucket|bucket of tadpole)|s = minecraft:bucket_of_tadpole
+	(tadpole bucket|bucket of tadpole)¦s = minecraft:bucket_of_tadpole
 
-	(disc|record) [5] fragment|s = minecraft:disc_fragment_5
+	(disc|record) [5] fragment¦s = minecraft:disc_fragment_5
 	[music] (disc|record) 5 = minecraft:music_disc_5
 	[any] [music] (disc|record) = any music disc, music disc 5
 
 	# sculk-related
-	echo shard|s = minecraft:echo_shard
+	echo shard¦s = minecraft:echo_shard
 	recovery compass¦es = minecraft:recovery_compass
 
 	{horn variations}:
@@ -357,4 +357,4 @@ the wild update:
 		call = -[instrument=minecraft:call_goat_horn]
 		yearn = -[instrument=minecraft:yearn_goat_horn]
 		dream = -[instrument=minecraft:dream_goat_horn]
-	{horn variations} goat horn|s = minecraft:goat_horn
+	{horn variations} goat horn¦s = minecraft:goat_horn

--- a/misc.sk
+++ b/misc.sk
@@ -333,3 +333,28 @@ caves and cliffs update part 2:
 	
 	[music] (disc|record) otherside = minecraft:music_disc_otherside
 	[any] [music] (disc|record) = any music disc, music disc otherside
+
+the wild update:
+	minecraft version = 1.19 or newer
+
+	(tadpole bucket|bucket of tadpole)|s = minecraft:bucket_of_tadpole
+
+	(disc|record) [5] fragment|s = minecraft:disc_fragment_5
+	[music] (disc|record) 5 = minecraft:music_disc_5
+	[any] [music] (disc|record) = any music disc, music disc 5
+
+	# sculk-related
+	echo shard|s = minecraft:echo_shard
+	recovery compass¦es = minecraft:recovery_compass
+
+	{horn variations}:
+		{default} = -
+		ponder = -[instrument=minecraft:ponder_goat_horn]
+		sing = -[instrument=minecraft:sing_goat_horn]
+		seek = -[instrument=minecraft:seek_goat_horn]
+		feel = -[instrument=minecraft:feel_goat_horn]
+		admire = -[instrument=minecraft:admire_goat_horn]
+		call = -[instrument=minecraft:call_goat_horn]
+		yearn = -[instrument=minecraft:yearn_goat_horn]
+		dream = -[instrument=minecraft:dream_goat_horn]
+	{horn variations} goat horn|s = minecraft:goat_horn

--- a/other.sk
+++ b/other.sk
@@ -272,6 +272,6 @@ caves and cliffs update part 1:
 	{waterloggable} {light level} light [block¦s] = minecraft:light
 	
 	# The following aliases will likely need to be moved to their 'proper' categories in the future
-	# As of 1.17, these items were not fully implemented
+	# As of 1.19, these items were not fully implemented
 	
 	bundle¦s = minecraft:bundle

--- a/other.sk
+++ b/other.sk
@@ -275,9 +275,3 @@ caves and cliffs update part 1:
 	# As of 1.17, these items were not fully implemented
 	
 	bundle¦s = minecraft:bundle
-	
-	{sculk sensor activity}:
-		{default} = -
-		active = -[sculk_sensor_phase=active]
-		cooldown = -[sculk_sensor_phase=cooldown]
-	{waterloggable} {sculk sensor activity} sculk sensor = minecraft:sculk_sensor

--- a/redstone.sk
+++ b/redstone.sk
@@ -276,3 +276,12 @@ global post flattening:
 	[any] door¦s = iron door, any wooden door
 	[any] button¦s = stone button, any wooden button
 	[any] trapdoor¦s = iron trapdoor, any wooden trapdoor
+
+the wild update:
+	minecraft version = 1.19 or newer
+
+	[any] wood[en] button¦s = wood button, mangrove button
+	[any] pressure plate¦s = pressure plate, mangrove pressure plate
+	[any] [fence] gate¦s = gate, mangrove gate
+	[any] wood[en] trapdoor¦s = wood trapdoor, mangrove trapdoor
+	[any] wood[en] door¦s = wood door, mangrove door

--- a/redstone.sk
+++ b/redstone.sk
@@ -262,6 +262,14 @@ caves and cliffs update part 1:
 	minecraft version = 1.17 or newer
 	
 	{waterloggable} {powerable} {orientable} lightning rod¦s = minecraft:lightning_rod
+	
+	# Sculk sencor has now placed on redstone since 1.19, but it existed since 1.17
+	{sculk sensor activity}:
+		{default} = -
+		active = -[sculk_sensor_phase=active]
+		cooldown = -[sculk_sensor_phase=cooldown]
+	{waterloggable} {sculk sensor activity} sculk sensor = minecraft:sculk_sensor
+
 
 global post flattening:
 	minecraft version = 1.13 or newer

--- a/redstone.sk
+++ b/redstone.sk
@@ -268,7 +268,7 @@ caves and cliffs update part 1:
 		{default} = -
 		active = -[sculk_sensor_phase=active]
 		cooldown = -[sculk_sensor_phase=cooldown]
-	{waterloggable} {sculk sensor activity} sculk sensor = minecraft:sculk_sensor
+	{waterloggable} {sculk sensor activity} sculk sensor¦s = minecraft:sculk_sensor
 
 
 global post flattening:
@@ -285,4 +285,4 @@ the wild update:
 	[any] [fence] gate¦s = gate, mangrove gate
 	[any] wood[en] trapdoor¦s = wood trapdoor, mangrove trapdoor
 	[any] wood[en] door¦s = wood door, mangrove door
-	[any] fence|s = fence, mangrove fence
+	[any] fence¦s = fence, mangrove fence

--- a/redstone.sk
+++ b/redstone.sk
@@ -285,3 +285,4 @@ the wild update:
 	[any] [fence] gate¦s = gate, mangrove gate
 	[any] wood[en] trapdoor¦s = wood trapdoor, mangrove trapdoor
 	[any] wood[en] door¦s = wood door, mangrove door
+	[any] fence|s = fence, mangrove fence

--- a/transportation.sk
+++ b/transportation.sk
@@ -121,13 +121,13 @@ the wild update:
 	minecraft version = 1.19 or newer
 
 	# boat with chest
-	spruce (chest boat|boat with chest)¦s = minecraft:spruce_chest_boat[relatedEntity=spruce chest boat]
-	birch (chest boat|boat with chest)¦s = minecraft:birch_chest_boat[relatedEntity=birch chest boat]
-	jungle (chest boat|boat with chest)¦s = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
-	acacia (chest boat|boat with chest)¦s = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
-	dark oak (chest boat|boat with chest)¦s = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
-	mangrove (chest boat|boat with chest)¦s = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
-	[any] (chest boat|boat with chest)¦s = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
+	spruce (chest boat¦s|boat¦s with chest) = minecraft:spruce_chest_boat[relatedEntity=spruce chest boat]
+	birch (chest boat¦s|boat¦s with chest) = minecraft:birch_chest_boat[relatedEntity=birch chest boat]
+	jungle (chest boat¦s|boat¦s with chest) = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
+	acacia (chest boat¦s|boat¦s with chest) = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
+	dark oak (chest boat¦s|boat¦s with chest) = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
+	mangrove (chest boat¦s|boat¦s with chest) = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
+	[any] (chest boat¦s|boat¦s with chest) = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
 
 	# mangrove
 	mangrove boat¦s = minecraft:mangrove_boat[relatedEntity=mangrove boat]

--- a/transportation.sk
+++ b/transportation.sk
@@ -115,7 +115,7 @@ unchanged rails:
 nether update:
 	minecraft version = 1.16 or newer
 
-	warped fungus on a stick¦s = minecraft:warped_fungus_on_a_stick
+	warped fungus on [a stick¦sticks] = minecraft:warped_fungus_on_a_stick
 
 the wild update:
 	minecraft version = 1.19 or newer

--- a/transportation.sk
+++ b/transportation.sk
@@ -116,3 +116,19 @@ nether update:
 	minecraft version = 1.16 or newer
 
 	warped fungus on a stick¦s = minecraft:warped_fungus_on_a_stick
+
+the wild update:
+	minecraft version = 1.19 or newer
+
+	# boat with chest
+	spruce (chest boat|boat with chest)¦s = minecraft:spruce_chest_boat[relatedEntity=spruce chest boat]
+	birch (chest boat|boat with chest)¦s = minecraft:birch_chest_boat[relatedEntity=birch chest boat]
+	jungle (chest boat|boat with chest)¦s = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
+	acacia (chest boat|boat with chest)¦s = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
+	dark oak (chest boat|boat with chest)¦s = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
+	mangrove (chest boat|boat with chest)|s = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
+	[any] (chest boat|boat with chest)|s = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
+
+	# mangrove
+	mangrove boat|s = minecraft:mangrove_boat[relatedEntity=mangrove boat]
+	[any] boat|s = any boat, any chest boat, mangrove boat

--- a/transportation.sk
+++ b/transportation.sk
@@ -115,7 +115,7 @@ unchanged rails:
 nether update:
 	minecraft version = 1.16 or newer
 
-	warped fungus on [a stick¦sticks] = minecraft:warped_fungus_on_a_stick
+	warped fungus on a stick = minecraft:warped_fungus_on_a_stick
 
 the wild update:
 	minecraft version = 1.19 or newer

--- a/transportation.sk
+++ b/transportation.sk
@@ -126,9 +126,9 @@ the wild update:
 	jungle (chest boat|boat with chest)¦s = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
 	acacia (chest boat|boat with chest)¦s = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
 	dark oak (chest boat|boat with chest)¦s = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
-	mangrove (chest boat|boat with chest)|s = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
-	[any] (chest boat|boat with chest)|s = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
+	mangrove (chest boat|boat with chest)¦s = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
+	[any] (chest boat|boat with chest)¦s = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
 
 	# mangrove
-	mangrove boat|s = minecraft:mangrove_boat[relatedEntity=mangrove boat]
-	[any] boat|s = any boat, any chest boat, mangrove boat
+	mangrove boat¦s = minecraft:mangrove_boat[relatedEntity=mangrove boat]
+	[any] boat¦s = any boat, any chest boat, mangrove boat

--- a/transportation.sk
+++ b/transportation.sk
@@ -131,4 +131,4 @@ the wild update:
 
 	# mangrove
 	mangrove boat¦s = minecraft:mangrove_boat[relatedEntity=mangrove boat]
-	[any] boat¦s = any boat, any chest boat, mangrove boat
+	[any] boat¦s = any boat, mangrove boat


### PR DESCRIPTION
This implements every item/block added at 1.19.

Not still tested, but this should work (maybe) since without code changes skript just loads on 1.19. (Plugin tested on Paper 1.19)