### PR TITLE
Fix quoted NBT tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Aliases can define NBT tags to apply for items. The tags should be in Mojang's
 JSON format that Vanilla commands such as /give use. Tags are put after item
 id, separated with a space:
 ```
-mundane potion = minecraft:potion {"Potion": "minecraft:mundane"}
+mundane potion = minecraft:potion {Potion: "minecraft:mundane"}
 ```
 If there are multiple ids defined for an alias, each of them can have their
 own tags specified before the next id is given.
@@ -72,8 +72,8 @@ some differences. For example potions are like this: they all share an id, but
 have their own tags. In these cases, it might make sense to define a variation:
 ```
 {potions}:
-    mundane = - {"Potion": "minecraft:mundane"}
-    awkward = - {"Potion": "mineraft:awkward"}
+    mundane = - {Potion: "minecraft:mundane"}
+    awkward = - {Potion: "mineraft:awkward"}
 {potions} potion = minecraft:potion
 ```
 Basically, in place of {potions}, there can be either mundane or awkward. What

--- a/brewing.sk
+++ b/brewing.sk
@@ -1,65 +1,65 @@
 potions:
 	[(glass|empty)] bottle¦s = minecraft:glass_bottle
-	(bottle[s] of water|water bottle¦s) = minecraft:potion {"Potion": "minecraft:water"}
+	(bottle[s] of water|water bottle¦s) = minecraft:potion {Potion: "minecraft:water"}
 
 	{potion types}:
 		{default} = - # Match all potions
-		water = - {"Potion": "minecraft:water"}
-		thick = - {"Potion": "minecraft:thick"}
-		mundane = - {"Potion": "minecraft:mundane"}
-		awkward = - {"Potion": "minecraft:awkward"}
+		water = - {Potion: "minecraft:water"}
+		thick = - {Potion: "minecraft:thick"}
+		mundane = - {Potion: "minecraft:mundane"}
+		awkward = - {Potion: "minecraft:awkward"}
 
-		night vision = - {"Potion": "minecraft:night_vision"}
-		(extended|long) night vision = - {"Potion": "minecraft:long_night_vision"}
+		night vision = - {Potion: "minecraft:night_vision"}
+		(extended|long) night vision = - {Potion: "minecraft:long_night_vision"}
 
-		invisibility = - {"Potion": "minecraft:invisibility"}
-		(extended|long) invisibility = - {"Potion": "minecraft:long_invisibility"}
+		invisibility = - {Potion: "minecraft:invisibility"}
+		(extended|long) invisibility = - {Potion: "minecraft:long_invisibility"}
 
-		(leaping|jumping) = - {"Potion": "minecraft:leaping"}
-		(extended|long) (leaping|jumping) = - {"Potion": "minecraft:long_leaping"}
-		(strong|upgraded|level 2) (leaping|jumping) = - {"Potion": "minecraft:strong_leaping"}
+		(leaping|jumping) = - {Potion: "minecraft:leaping"}
+		(extended|long) (leaping|jumping) = - {Potion: "minecraft:long_leaping"}
+		(strong|upgraded|level 2) (leaping|jumping) = - {Potion: "minecraft:strong_leaping"}
 
-		fire resistance = - {"Potion": "minecraft:fire_resistance"}
-		(extended|long) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
+		fire resistance = - {Potion: "minecraft:fire_resistance"}
+		(extended|long) fire resistance = - {Potion: "minecraft:long_fire_resistance"}
 
-		(speed|swiftness) = - {"Potion": "minecraft:swiftness"}
-		(extended|long) (speed|swiftness) = - {"Potion": "minecraft:long_swiftness"}
-		(strong|upgraded|level 2) (speed|swiftness) = - {"Potion": "minecraft:strong_swiftness"}
+		(speed|swiftness) = - {Potion: "minecraft:swiftness"}
+		(extended|long) (speed|swiftness) = - {Potion: "minecraft:long_swiftness"}
+		(strong|upgraded|level 2) (speed|swiftness) = - {Potion: "minecraft:strong_swiftness"}
 
-		slow[ness] = - {"Potion": "minecraft:slowness"}
-		(extended|long) slow[ness] = - {"Potion": "minecraft:long_slowness"}
-		(strong|upgraded|level 2) slow[ness] = - {"Potion": "minecraft:strong_slowness"}
+		slow[ness] = - {Potion: "minecraft:slowness"}
+		(extended|long) slow[ness] = - {Potion: "minecraft:long_slowness"}
+		(strong|upgraded|level 2) slow[ness] = - {Potion: "minecraft:strong_slowness"}
 
-		turtle master = - {"Potion": "minecraft:turtle_master"}
-		(extended|long) turtle master = - {"Potion": "minecraft:long_turtle_master"}
-		(strong|upgraded|level 2) turtle master = - {"Potion": "minecraft:strong_turtle_master"}
+		turtle master = - {Potion: "minecraft:turtle_master"}
+		(extended|long) turtle master = - {Potion: "minecraft:long_turtle_master"}
+		(strong|upgraded|level 2) turtle master = - {Potion: "minecraft:strong_turtle_master"}
 
-		water breathing = - {"Potion": "minecraft:water_breathing"}
-		(extended|long) water breathing = - {"Potion": "minecraft:long_water_breathing"}
+		water breathing = - {Potion: "minecraft:water_breathing"}
+		(extended|long) water breathing = - {Potion: "minecraft:long_water_breathing"}
 
-		heal(th|ing) = - {"Potion": "minecraft:healing"}
-		(strong|upgraded|level 2) heal(th|ing) = - {"Potion": "minecraft:strong_healing"}
+		heal(th|ing) = - {Potion: "minecraft:healing"}
+		(strong|upgraded|level 2) heal(th|ing) = - {Potion: "minecraft:strong_healing"}
 
-		harming = - {"Potion": "minecraft:harming"}
-		(strong|upgraded|level 2) harming = - {"Potion": "minecraft:strong_harming"}
+		harming = - {Potion: "minecraft:harming"}
+		(strong|upgraded|level 2) harming = - {Potion: "minecraft:strong_harming"}
 
-		poison[ing] = - {"Potion": "minecraft:poison"}
-		(extended|long) poison[ing] = - {"Potion": "minecraft:long_poison"}
-		(strong|upgraded|level 2) poison[ing] = - {"Potion": "minecraft:strong_poison"}
+		poison[ing] = - {Potion: "minecraft:poison"}
+		(extended|long) poison[ing] = - {Potion: "minecraft:long_poison"}
+		(strong|upgraded|level 2) poison[ing] = - {Potion: "minecraft:strong_poison"}
 
-		regen[eration] = - {"Potion": "minecraft:regeneration"}
-		(extended|long) regen[eration] = - {"Potion": "minecraft:long_regeneration"}
-		(strong|upgraded|level 2) regen[eration] = - {"Potion": "minecraft:strong_regeneration"}
+		regen[eration] = - {Potion: "minecraft:regeneration"}
+		(extended|long) regen[eration] = - {Potion: "minecraft:long_regeneration"}
+		(strong|upgraded|level 2) regen[eration] = - {Potion: "minecraft:strong_regeneration"}
 
-		strength = - {"Potion": "minecraft:strength"}
-		(extended|long) strength = - {"Potion": "minecraft:long_strength"}
-		(strong|upgraded|level 2) strength = - {"Potion": "minecraft:strong_strength"}
+		strength = - {Potion: "minecraft:strength"}
+		(extended|long) strength = - {Potion: "minecraft:long_strength"}
+		(strong|upgraded|level 2) strength = - {Potion: "minecraft:strong_strength"}
 
-		weak(ness|ening) = - {"Potion": "minecraft:weakness"}
-		(extended|long) weak(ness|ening) = - {"Potion": "minecraft:long_weakness"}
+		weak(ness|ening) = - {Potion: "minecraft:weakness"}
+		(extended|long) weak(ness|ening) = - {Potion: "minecraft:long_weakness"}
 
-		slow fall[ing] = - {"Potion": "minecraft:slow_falling"}
-		(extended|long) slow fall[ing] = - {"Potion": "minecraft:long_slow_falling"}
+		slow fall[ing] = - {Potion: "minecraft:slow_falling"}
+		(extended|long) slow fall[ing] = - {Potion: "minecraft:long_slow_falling"}
 
 	(potion[s] of {potion types}|{potion types} potion¦s) = minecraft:potion
 	(splash potion[s] of {potion types}|{potion types} splash potion¦s) = minecraft:splash_potion
@@ -103,7 +103,7 @@ combat update brewing:
 	dragon['s] breath = minecraft:dragon_breath
 
 	{combat update potions}:
-		luck = - {"Potion": "minecraft:luck"}
+		luck = - {Potion: "minecraft:luck"}
 
 	(potion[s] of {combat update potions}|{combat update potions} potion¦s) = minecraft:potion
 	(splash potion[s] of {combat update potions}|{combat update potions} splash potion¦s) = minecraft:splash_potion

--- a/combat.sk
+++ b/combat.sk
@@ -4,39 +4,39 @@ combat update:
 
 	{tipped arrow types}:
 		{default} = -
-		night vision = - {"Potion": "minecraft:night_vision"}
-		(long|extended) night vision = - {"Potion": "minecraft:long_night_vision"}
-		invisibility = - {"Potion": "minecraft:invisibility"}
-		(long|extended) invisibility = - {"Potion": "minecraft:long_invisibility"}
-		leaping = - {"Potion": "minecraft:leaping"}
-		(long|extended) leaping = - {"Potion": "minecraft:long_leaping"}
-		(strong|upgraded|level 2) leaping = - {"Potion": "minecraft:strong_leaping"}
-		fire resistance = - {"Potion": "minecraft:fire_resistance"}
-		(long|extended) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
-		(swiftness|speed) = - {"Potion": "minecraft:swiftness"}
-		(long|extended) (swiftness|speed) = - {"Potion": "minecraft:long_swiftness"}
-		(strong|upgraded|level 2) (swiftness|speed) = - {"Potion": "minecraft:strong_swiftness"}
-		slowness = - {"Potion": "minecraft:slowness"}
-		(long|extended) slowness = - {"Potion": "minecraft:long_slowness"}
-		(strong|upgraded|level 2) slowness = - {"Potion": "minecraft:strong_slowness"}
-		water breathing = - {"Potion": "minecraft:water_breathing"}
-		(long|extended) water breathing = - {"Potion": "minecraft:long_water_breathing"}
-		(healing|instant health) = - {"Potion": "minecraft:healing"}
-		(strong|upgraded|level 2) (healing|instant health) = - {"Potion": "minecraft:strong_healing"}
-		[instant] (harming|damage) = - {"Potion": "minecraft:harming"}
-		(strong|upgraded|level 2) [instant] (harming|damage) = - {"Potion": "minecraft:strong_harming"}
-		poison = - {"Potion": "minecraft:poison"}
-		(long|extended) poison = - {"Potion": "minecraft:long_poison"}
-		(strong|upgraded|level 2) poison = - {"Potion": "minecraft:strong_poison"}
-		regen[eration] = - {"Potion": "minecraft:regeneration"}
-		(long|extended) regen[eration] = - {"Potion": "minecraft:long_regeneration"}
-		(strong|upgraded|level 2) regen[eration] = - {"Potion": "minecraft:strong_regeneration"}
-		strength = - {"Potion": "minecraft:strength"}
-		(long|extended) strength = - {"Potion": "minecraft:long_strength"}
-		(strong|upgraded|level 2) strength = - {"Potion": "minecraft:strong_strength"}
-		weakness = - {"Potion": "minecraft:weakness"}
-		(long|extended) weakness = - {"Potion": "minecraft:long_weakness"}
-		luck = - {"Potion": "minecraft:luck"}
+		night vision = - {Potion: "minecraft:night_vision"}
+		(long|extended) night vision = - {Potion: "minecraft:long_night_vision"}
+		invisibility = - {Potion: "minecraft:invisibility"}
+		(long|extended) invisibility = - {Potion: "minecraft:long_invisibility"}
+		leaping = - {Potion: "minecraft:leaping"}
+		(long|extended) leaping = - {Potion: "minecraft:long_leaping"}
+		(strong|upgraded|level 2) leaping = - {Potion: "minecraft:strong_leaping"}
+		fire resistance = - {Potion: "minecraft:fire_resistance"}
+		(long|extended) fire resistance = - {Potion: "minecraft:long_fire_resistance"}
+		(swiftness|speed) = - {Potion: "minecraft:swiftness"}
+		(long|extended) (swiftness|speed) = - {Potion: "minecraft:long_swiftness"}
+		(strong|upgraded|level 2) (swiftness|speed) = - {Potion: "minecraft:strong_swiftness"}
+		slowness = - {Potion: "minecraft:slowness"}
+		(long|extended) slowness = - {Potion: "minecraft:long_slowness"}
+		(strong|upgraded|level 2) slowness = - {Potion: "minecraft:strong_slowness"}
+		water breathing = - {Potion: "minecraft:water_breathing"}
+		(long|extended) water breathing = - {Potion: "minecraft:long_water_breathing"}
+		(healing|instant health) = - {Potion: "minecraft:healing"}
+		(strong|upgraded|level 2) (healing|instant health) = - {Potion: "minecraft:strong_healing"}
+		[instant] (harming|damage) = - {Potion: "minecraft:harming"}
+		(strong|upgraded|level 2) [instant] (harming|damage) = - {Potion: "minecraft:strong_harming"}
+		poison = - {Potion: "minecraft:poison"}
+		(long|extended) poison = - {Potion: "minecraft:long_poison"}
+		(strong|upgraded|level 2) poison = - {Potion: "minecraft:strong_poison"}
+		regen[eration] = - {Potion: "minecraft:regeneration"}
+		(long|extended) regen[eration] = - {Potion: "minecraft:long_regeneration"}
+		(strong|upgraded|level 2) regen[eration] = - {Potion: "minecraft:strong_regeneration"}
+		strength = - {Potion: "minecraft:strength"}
+		(long|extended) strength = - {Potion: "minecraft:long_strength"}
+		(strong|upgraded|level 2) strength = - {Potion: "minecraft:strong_strength"}
+		weakness = - {Potion: "minecraft:weakness"}
+		(long|extended) weakness = - {Potion: "minecraft:long_weakness"}
+		luck = - {Potion: "minecraft:luck"}
 
 	spectral arrow¦s = minecraft:spectral_arrow[relatedEntity=spectral arrow]
 	{tipped arrow types} tipped arrow¦s = minecraft:tipped_arrow
@@ -126,11 +126,11 @@ update aquatic combat items:
 	trident¦s = minecraft:trident[relatedEntity=trident]
 
 	{update aquatic effects}:
-		turtle master = - {"Potion": "minecraft:turtle_master"}
-		(long|extended) turtle master = - {"Potion": "minecraft:long_turtle_master"}
-		(strong|upgraded|level 2) turtle master = - {"Potion": "minecraft:strong_turtle_master"}
-		slow fall[ing] = - {"Potion": "minecraft:slow_falling"}
-		(long|extended) slow fall[ing] = - {"Potion": "minecraft:long_slow_falling"}
+		turtle master = - {Potion: "minecraft:turtle_master"}
+		(long|extended) turtle master = - {Potion: "minecraft:long_turtle_master"}
+		(strong|upgraded|level 2) turtle master = - {Potion: "minecraft:strong_turtle_master"}
+		slow fall[ing] = - {Potion: "minecraft:slow_falling"}
+		(long|extended) slow fall[ing] = - {Potion: "minecraft:long_slow_falling"}
 
 	{update aquatic effects} tipped arrow¦s = minecraft:tipped_arrow
 	tipped arrow[s] of {update aquatic effects} = minecraft:tipped_arrow

--- a/misc.sk
+++ b/misc.sk
@@ -352,13 +352,13 @@ the wild update:
 	# Horns
 	{horn variations}:
 		{default} = -
-		ponder = - {"instrument": "minecraft:ponder_goat_horn"}
-		sing = - {"instrument": "minecraft:sing_goat_horn"}
-		seek = - {"instrument": "minecraft:seek_goat_horn"}
-		feel = - {"instrument": "minecraft:feel_goat_horn"}
-		admire = - {"instrument": "minecraft:admire_goat_horn"}
-		call = - {"instrument": "minecraft:call_goat_horn"}
-		yearn = - {"instrument": "minecraft:yearn_goat_horn"}
-		dream = - {"instrument": "minecraft:dream_goat_horn"}
+		ponder = - {instrument:"minecraft:ponder_goat_horn"}
+		sing = - {instrument:"minecraft:sing_goat_horn"}
+		seek = - {instrument:"minecraft:seek_goat_horn"}
+		feel = - {instrument:"minecraft:feel_goat_horn"}
+		admire = - {instrument:"minecraft:admire_goat_horn"}
+		call = - {instrument:"minecraft:call_goat_horn"}
+		yearn = - {instrument:"minecraft:yearn_goat_horn"}
+		dream = - {instrument:"minecraft:dream_goat_horn"}
 		
 	{horn variations} goat horn¦s = minecraft:goat_horn


### PR DESCRIPTION
Fixes NBT tags on potions and goat horns to not have quotes for the keys in its NBT tags

See https://github.com/SkriptLang/Skript/pull/4965