### PR TITLE
Aliases for 1.20

### DIFF
--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -267,6 +267,26 @@ block states:
 		acacia = minecraft:acacia_-
 		dark oak = minecraft:dark_oak_-
 
+	# Stairs
+	{stairs}:
+		{default} = -
+		top = -[half=top]
+		bottom = -[half=bottom]
+	{stairs shape}:
+		{default} = -
+		straight = -[shape=straight]
+		inner-left = -[shape=inner_left]
+		inner-right = -[shape=inner_right]
+		outer-left = -[shape=outer_left]
+		outer-right = -[shape=outer_right]
+
+	#Slabs
+	{slab}:
+		{default} = -
+		top = -[type=top]
+		bottom = -[type=bottom]
+		double = -[type=double]
+
 # Aliases that can be used in at least one place both pre and post-flattening.
 pre-nether-update woods:
 	minecraft version = 1.15.2 or older
@@ -329,3 +349,12 @@ wild-update woods:
 		mangrove [wood] = minecraft:mangrove_-
 		cherry [wood] = minecraft:cherry_-
 		bamboo [wood] = minecraft:bamboo_-
+
+	{tree type}:
+		oak = minecraft:oak_-
+		spruce = minecraft:spruce_-
+		birch = minecraft:birch_-
+		jungle = minecraft:jungle_-
+		acacia = minecraft:acacia_-
+		dark oak = minecraft:dark_oak_-
+		cherry = minecraft:cherry_-

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -280,7 +280,7 @@ block states:
 		outer-left = -[shape=outer_left]
 		outer-right = -[shape=outer_right]
 
-	#Slabs
+	# Slabs
 	{slab}:
 		{default} = -
 		top = -[type=top]

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -336,7 +336,6 @@ wild-update woods:
 wild-update woods:
 	minecraft version = 1.20 or newer
 
-    # For wood-based blocks that are defined with the wood type at the start of the alias.
 	{wood type}:
 		oak [wood] = minecraft:oak_-
 		spruce [wood] = minecraft:spruce_-

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -312,3 +312,20 @@ wild-update woods:
 		crimson = minecraft:crimson_-
 		warped = minecraft:warped_-
 		mangrove [wood] = minecraft:mangrove_-
+
+wild-update woods:
+	minecraft version = 1.20 or newer
+
+    # For wood-based blocks that are defined with the wood type at the start of the alias.
+	{wood type}:
+		oak [wood] = minecraft:oak_-
+		spruce [wood] = minecraft:spruce_-
+		birch [wood] = minecraft:birch_-
+		jungle [wood] = minecraft:jungle_-
+		acacia [wood] = minecraft:acacia_-
+		dark oak [wood] = minecraft:dark_oak_-
+		crimson = minecraft:crimson_-
+		warped = minecraft:warped_-
+		mangrove [wood] = minecraft:mangrove_-
+		cherry [wood] = minecraft:cherry_-
+		bamboo [wood] = minecraft:bamboo_-

--- a/building.sk
+++ b/building.sk
@@ -829,6 +829,6 @@ trails and tales update:
 	{waterloggable} {stairs} {stairs shape} {directional} bamboo [wood[en]] mosaic stairs¦s = minecraft:bamboo_mosaic_stairs
 	[any] wood[en] stair¦s = any wooden stairs, bamboo stairs, bamboo mosaic stairs
 	[any] stair¦s = any stairs, bamboo mosaic stairs
-	{waterloggable} {slab} bamboo mosaic slab¦s = minecraft:bamboo mosaic_slab
+	{waterloggable} {slab} bamboo mosaic slab¦s = minecraft:bamboo_mosaic_slab
 	[any] wood[en] slab¦s = any wooden slab, bamboo mosaic slab
 	[any] slab¦s = any slab, bamboo mosaic slab

--- a/building.sk
+++ b/building.sk
@@ -821,3 +821,25 @@ the wild update:
 
 	{axis-aligned} stripped mangrove log¦s = minecraft:stripped_mangrove_log
 	[any] stripped log [block¦s] = any stripped log, stripped mangrove log
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	[any] stairs = any stairs, cherry stairs
+
+	{axis-aligned} cherry (wood|bark) [block¦s] = minecraft:cherry_wood
+	[any] wood¦s = any wood, cherry wood
+
+	{waterloggable} {slab} cherry slab¦s = minecraft:cherry_slab
+	[any] wood[en] slab¦s = any wooden slab, cherry slab
+	[any] slab¦s = any slab, cherry slab
+	[any] [wood[en]] plank¦s = any wooden plank, cherry planks
+
+	{axis-aligned} cherry log¦s = minecraft:cherry_log
+	[any] log¦s = any log, cherry log
+
+	{axis-aligned} stripped cherry (bark|wood) [block¦s] = minecraft:stripped_cherry_wood
+	[any] stripped (bark|wood) [block¦s] = any stripped bark, stripped cherry bark
+
+	{axis-aligned} stripped cherry log¦s = minecraft:stripped_cherry_log
+	[any] stripped log [block¦s] = any stripped log, stripped cherry log

--- a/building.sk
+++ b/building.sk
@@ -348,19 +348,6 @@ building blocks after flattening:
 	[any] wood[en] slab¦s = oak slab, spruce slab, birch slab, jungle slab, acacia slab, dark oak slab
 	[any] slab¦s = any wooden slab, stone slab, sandstone slab, petrified oak slab, cobblestone slab, brick slab, stone brick slab, nether brick slab, quartz slab, red sandstone slab, purpur slab, prismarine slab, prismarine brick slab, dark prismarine slab
 
-	# Stairs
-	{stairs}:
-		{default} = -
-		top = -[half=top]
-		bottom = -[half=bottom]
-	{stairs shape}:
-		{default} = -
-		straight = -[shape=straight]
-		inner-left = -[shape=inner_left]
-		inner-right = -[shape=inner_right]
-		outer-left = -[shape=outer_left]
-		outer-right = -[shape=outer_right]
-
 	{waterloggable} {stairs} {stairs shape} {directional} {wood type} stair¦s = -stairs
 	{waterloggable} {stairs} {stairs shape} {directional} cobble[stone] stair¦s = minecraft:cobblestone_stairs
 	{waterloggable} {stairs} {stairs shape} {directional} [red] brick stair¦s = minecraft:brick_stairs
@@ -568,18 +555,7 @@ update aquatic:
 
 village and pillage update:
 	minecraft version = 1.14 or newer
-	# Stairs
-	{stairs}:
-		{default} = -
-		top = -[half=top]
-		bottom = -[half=bottom]
-	{stairs shape}:
-		{default} = -
-		straight = -[shape=straight]
-		inner-left = -[shape=inner_left]
-		inner-right = -[shape=inner_right]
-		outer-left = -[shape=outer_left]
-		outer-right = -[shape=outer_right]
+
 	#Stairs
 	{waterloggable} {stairs} {stairs shape} {directional} stone stair¦s = minecraft:stone_stairs
 	{waterloggable} {stairs} {stairs shape} {directional} granite stair¦s = minecraft:granite_stairs
@@ -598,14 +574,6 @@ village and pillage update:
 	any stone stair¦s = stone stairs, granite stairs, diorite stairs, andesite stairs, polished granite stairs, polished diorite stairs, polished andesite stairs, stone brick stairs, mossy stone brick stairs, cobblestone stairs, mossy cobblestone stairs
 	[any] sandstone stair¦s = sandstone stairs, smooth sandstone stairs, red sandstone stairs, smooth red sandstone stairs
 	[any] stair¦s = any wood stairs, any stone stairs, any sandstone stairs, brick stairs, nether brick stairs, quartz stairs, purpur stairs, prismarine stairs, prismarine brick stairs, dark prismarine stairs, smooth quartz stairs, red nether brick stairs, end stone brick stairs
-
-
-	#Slabs
-	{slab}:
-		{default} = -
-		top = -[type=top]
-		bottom = -[type=bottom]
-		double = -[type=double]
 		
 	{waterloggable} {slab} stone slab¦s = minecraft:stone_slab
 	{waterloggable} {slab} smooth stone slab¦s = minecraft:smooth_stone_slab
@@ -825,21 +793,42 @@ the wild update:
 trails and tales update:
 	minecraft version = 1.20 or newer
 
+	# Cherry wood
 	[any] stairs = any stairs, cherry stairs
 
 	{axis-aligned} cherry (wood|bark) [block¦s] = minecraft:cherry_wood
 	[any] wood¦s = any wood, cherry wood
 
-	{waterloggable} {slab} cherry slab¦s = minecraft:cherry_slab
+	{axis-aligned} cherry log¦s = minecraft:cherry_log
+	[any] log¦s = any log, cherry log
+
 	[any] wood[en] slab¦s = any wooden slab, cherry slab
 	[any] slab¦s = any slab, cherry slab
 	[any] [wood[en]] plank¦s = any wooden plank, cherry planks
-
-	{axis-aligned} cherry log¦s = minecraft:cherry_log
-	[any] log¦s = any log, cherry log
 
 	{axis-aligned} stripped cherry (bark|wood) [block¦s] = minecraft:stripped_cherry_wood
 	[any] stripped (bark|wood) [block¦s] = any stripped bark, stripped cherry bark
 
 	{axis-aligned} stripped cherry log¦s = minecraft:stripped_cherry_log
 	[any] stripped log [block¦s] = any stripped log, stripped cherry log
+
+	# Bamboo wood
+	[any] stairs = any stairs, bamboo stairs
+
+	# Reminder that bamboo is slightly different than a wood log, but still has similar principles, don't copy section for new wood.
+	{axis-aligned} bamboo [wood] block¦s = minecraft:bamboo_block
+	{axis-aligned} stripped bamboo [wood] block¦s = minecraft:stripped_bamboo_block
+	[any] stripped (bark|wood) [block¦s] = any stripped wood, stripped bamboo wood block
+	[any] wood¦s = any wood, bamboo block, stripped bamboo wood block
+
+	[any] wood[en] slab¦s = any wooden slab, bamboo slab
+	[any] slab¦s = any slab, bamboo slab
+	[any] [wood[en]] plank¦s = any wooden plank, bamboo planks
+
+	bamboo [wood[en]] mosaic¦s = minecraft:bamboo_mosaic
+	{waterloggable} {stairs} {stairs shape} {directional} bamboo [wood[en]] mosaic stairs¦s = minecraft:bamboo_mosaic_stairs
+	[any] wood[en] stair¦s = any wooden stairs, bamboo stairs, bamboo mosaic stairs
+	[any] stair¦s = any stairs, bamboo mosaic stairs
+	{waterloggable} {slab} bamboo mosaic slab¦s = minecraft:bamboo mosaic_slab
+	[any] wood[en] slab¦s = any wooden slab, bamboo mosaic slab
+	[any] slab¦s = any slab, bamboo mosaic slab

--- a/combat.sk
+++ b/combat.sk
@@ -174,3 +174,233 @@ nether update:
 	[any] boots = leather boots, iron boots, gold boots, diamond boots, chain boots, netherite boots
 
 	[any] equipment = any weapon, any armor, shield
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	netherite [armo[u]r] [upgrade] smithing template¦s = minecraft:netherite_upgrade_smithing_template
+	sentry armo[u]r [trim] smithing template¦s = minecraft:sentry_armor_trim_smithing_template
+	vex armo[u]r [trim] smithing template¦s = minecraft:vex_armor_trim_smithing_template
+	wild armo[u]r [trim] smithing template¦s = minecraft:wild_armor_trim_smithing_template
+	coast armo[u]r [trim] smithing template¦s = minecraft:coast_armor_trim_smithing_template
+	dune armo[u]r [trim] smithing template¦s = minecraft:dune_armor_trim_smithing_template
+	wayfinder armo[u]r [trim] smithing template¦s = minecraft:wayfinder_armor_trim_smithing_template
+	raiser armo[u]r [trim] smithing template¦s = minecraft:raiser_armor_trim_smithing_template
+	shaper armo[u]r [trim] smithing template¦s = minecraft:shaper_armor_trim_smithing_template
+	host armo[u]r [trim] smithing template¦s = minecraft:host_armor_trim_smithing_template
+	ward armo[u]r [trim] smithing template¦s = minecraft:ward_armor_trim_smithing_template
+	silence armo[u]r [trim] smithing template¦s = minecraft:silence_armor_trim_smithing_template
+	tide armo[u]r [trim] smithing template¦s = minecraft:tide_armor_trim_smithing_template
+	snout armo[u]r [trim] smithing template¦s = minecraft:snout_armor_trim_smithing_template
+	rib armo[u]r [trim] smithing template¦s = minecraft:rib_armor_trim_smithing_template
+	eye armo[u]r [trim] smithing template¦s = minecraft:eye_armor_trim_smithing_template
+	spire armo[u]r [trim] smithing template¦s = minecraft:spire_armor_trim_smithing_template
+	[any] [armo[u]r] [trim] smithing template¦s = netherite armor smithing template, sentry armor smithing template, vex armor smithing template, wild armor smithing template, coast armor smithing template, dune armor smithing template, wayfinder armor smithing template, raiser armor smithing template, shaper armor smithing template, host armor smithing template, ward armor smithing template, silence armor smithing template, tide armor smithing template, snout armor smithing template, rib armor smithing template, eye armor smithing template, spire armor smithing template
+
+	{armor trims}:
+		{default} = -
+		(emerald|green) sentry = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:sentry"}}
+		(redstone|red) sentry = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:sentry"}}
+		(lapis [lazuli]|blue) sentry = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:sentry"}}
+		(amethyst [shard]|purple) sentry = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:sentry"}}
+		([nether] quartz|white) sentry = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:sentry"}}
+		(netherite|black) sentry = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:sentry"}}
+		(diamond|light blue) sentry = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:sentry"}}
+		(gold|yellow) sentry = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:sentry"}}
+		(iron|grey|gray) sentry = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:sentry"}}
+		(copper|brown) sentry = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:sentry"}}
+
+		(emerald|green) vex = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:vex"}}
+		(redstone|red) vex = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:vex"}}
+		(lapis [lazuli]|blue) vex = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:vex"}}
+		(amethyst [shard]|purple) vex = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:vex"}}
+		([nether] quartz|white) vex = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:vex"}}
+		(netherite|black) vex = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:vex"}}
+		(diamond|light blue) vex = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:vex"}}
+		(gold|yellow) vex = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:vex"}}
+		(iron|grey|gray) vex = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:vex"}}
+		(copper|brown) vex = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:vex"}}
+
+		(emerald|green) wild = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:wild"}}
+		(redstone|red) wild = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:wild"}}
+		(lapis [lazuli]|blue) wild = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:wild"}}
+		(amethyst [shard]|purple) wild = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:wild"}}
+		([nether] quartz|white) wild = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:wild"}}
+		(netherite|black) wild = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:wild"}}
+		(diamond|light blue) wild = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:wild"}}
+		(gold|yellow) wild = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:wild"}}
+		(iron|grey|gray) wild = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:wild"}}
+		(copper|brown) wild = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:wild"}}
+
+		(emerald|green) coast = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:coast"}}
+		(redstone|red) coast = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:coast"}}
+		(lapis [lazuli]|blue) coast = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:coast"}}
+		(amethyst [shard]|purple) coast = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:coast"}}
+		([nether] quartz|white) coast = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:coast"}}
+		(netherite|black) coast = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:coast"}}
+		(diamond|light blue) coast = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:coast"}}
+		(gold|yellow) coast = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:coast"}}
+		(iron|grey|gray) coast = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:coast"}}
+		(copper|brown) coast = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:coast"}}
+
+		(emerald|green) dune = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:dune"}}
+		(redstone|red) dune = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:dune"}}
+		(lapis [lazuli]|blue) dune = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:dune"}}
+		(amethyst [shard]|purple) dune = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:dune"}}
+		([nether] quartz|white) dune = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:dune"}}
+		(netherite|black) dune = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:dune"}}
+		(diamond|light blue) dune = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:dune"}}
+		(gold|yellow) dune = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:dune"}}
+		(iron|grey|gray) dune = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:dune"}}
+		(copper|brown) dune = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:dune"}}
+
+		(emerald|green) wayfinder = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:wayfinder"}}
+		(redstone|red) wayfinder = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:wayfinder"}}
+		(lapis [lazuli]|blue) wayfinder = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:wayfinder"}}
+		(amethyst [shard]|purple) wayfinder = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:wayfinder"}}
+		([nether] quartz|white) wayfinder = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:wayfinder"}}
+		(netherite|black) wayfinder = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:wayfinder"}}
+		(diamond|light blue) wayfinder = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:wayfinder"}}
+		(gold|yellow) wayfinder = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:wayfinder"}}
+		(iron|grey|gray) wayfinder = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:wayfinder"}}
+		(copper|brown) wayfinder = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:wayfinder"}}
+
+		(emerald|green) raiser = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:raiser"}}
+		(redstone|red) raiser = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:raiser"}}
+		(lapis [lazuli]|blue) raiser = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:raiser"}}
+		(amethyst [shard]|purple) raiser = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:raiser"}}
+		([nether] quartz|white) raiser = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:raiser"}}
+		(netherite|black) raiser = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:raiser"}}
+		(diamond|light blue) raiser = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:raiser"}}
+		(gold|yellow) raiser = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:raiser"}}
+		(iron|grey|gray) raiser = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:raiser"}}
+		(copper|brown) raiser = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:raiser"}}
+
+		(emerald|green) shaper = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:shaper"}}
+		(redstone|red) shaper = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:shaper"}}
+		(lapis [lazuli]|blue) shaper = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:shaper"}}
+		(amethyst [shard]|purple) shaper = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:shaper"}}
+		([nether] quartz|white) shaper = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:shaper"}}
+		(netherite|black) shaper = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:shaper"}}
+		(diamond|light blue) shaper = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:shaper"}}
+		(gold|yellow) shaper = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:shaper"}}
+		(iron|grey|gray) shaper = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:shaper"}}
+		(copper|brown) shaper = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:shaper"}}
+
+		(emerald|green) host = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:host"}}
+		(redstone|red) host = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:host"}}
+		(lapis [lazuli]|blue) host = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:host"}}
+		(amethyst [shard]|purple) host = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:host"}}
+		([nether] quartz|white) host = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:host"}}
+		(netherite|black) host = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:host"}}
+		(diamond|light blue) host = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:host"}}
+		(gold|yellow) host = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:host"}}
+		(iron|grey|gray) host = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:host"}}
+		(copper|brown) host = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:host"}}
+
+		(emerald|green) ward = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:ward"}}
+		(redstone|red) ward = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:ward"}}
+		(lapis [lazuli]|blue) ward = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:ward"}}
+		(amethyst [shard]|purple) ward = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:ward"}}
+		([nether] quartz|white) ward = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:ward"}}
+		(netherite|black) ward = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:ward"}}
+		(diamond|light blue) ward = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:ward"}}
+		(gold|yellow) ward = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:ward"}}
+		(iron|grey|gray) ward = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:ward"}}
+		(copper|brown) ward = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:ward"}}
+
+		(emerald|green) silence = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:silence"}}
+		(redstone|red) silence = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:silence"}}
+		(lapis [lazuli]|blue) silence = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:silence"}}
+		(amethyst [shard]|purple) silence = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:silence"}}
+		([nether] quartz|white) silence = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:silence"}}
+		(netherite|black) silence = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:silence"}}
+		(diamond|light blue) silence = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:silence"}}
+		(gold|yellow) silence = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:silence"}}
+		(iron|grey|gray) silence = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:silence"}}
+		(copper|brown) silence = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:silence"}}
+
+		(emerald|green) tide = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:tide"}}
+		(redstone|red) tide = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:tide"}}
+		(lapis [lazuli]|blue) tide = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:tide"}}
+		(amethyst [shard]|purple) tide = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:tide"}}
+		([nether] quartz|white) tide = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:tide"}}
+		(netherite|black) tide = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:tide"}}
+		(diamond|light blue) tide = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:tide"}}
+		(gold|yellow) tide = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:tide"}}
+		(iron|grey|gray) tide = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:tide"}}
+		(copper|brown) tide = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:tide"}}
+
+		(emerald|green) snout = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:snout"}}
+		(redstone|red) snout = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:snout"}}
+		(lapis [lazuli]|blue) snout = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:snout"}}
+		(amethyst [shard]|purple) snout = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:snout"}}
+		([nether] quartz|white) snout = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:snout"}}
+		(netherite|black) snout = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:snout"}}
+		(diamond|light blue) snout = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:snout"}}
+		(gold|yellow) snout = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:snout"}}
+		(iron|grey|gray) snout = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:snout"}}
+		(copper|brown) snout = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:snout"}}
+
+		(emerald|green) rib = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:rib"}}
+		(redstone|red) rib = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:rib"}}
+		(lapis [lazuli]|blue) rib = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:rib"}}
+		(amethyst [shard]|purple) rib = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:rib"}}
+		([nether] quartz|white) rib = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:rib"}}
+		(netherite|black) rib = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:rib"}}
+		(diamond|light blue) rib = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:rib"}}
+		(gold|yellow) rib = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:rib"}}
+		(iron|grey|gray) rib = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:rib"}}
+		(copper|brown) rib = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:rib"}}
+
+		(emerald|green) eye = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:eye"}}
+		(redstone|red) eye = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:eye"}}
+		(lapis [lazuli]|blue) eye = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:eye"}}
+		(amethyst [shard]|purple) eye = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:eye"}}
+		([nether] quartz|white) eye = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:eye"}}
+		(netherite|black) eye = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:eye"}}
+		(diamond|light blue) eye = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:eye"}}
+		(gold|yellow) eye = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:eye"}}
+		(iron|grey|gray) eye = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:eye"}}
+		(copper|brown) eye = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:eye"}}
+
+		(emerald|green) spire = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:spire"}}
+		(redstone|red) spire = - {"Trim": {"material": "minecraft:redstone", "pattern": "minecraft:spire"}}
+		(lapis [lazuli]|blue) spire = - {"Trim": {"material": "minecraft:lapis", "pattern": "minecraft:spire"}}
+		(amethyst [shard]|purple) spire = - {"Trim": {"material": "minecraft:amethyst", "pattern": "minecraft:spire"}}
+		([nether] quartz|white) spire = - {"Trim": {"material": "minecraft:quartz", "pattern": "minecraft:spire"}}
+		(netherite|black) spire = - {"Trim": {"material": "minecraft:netherite", "pattern": "minecraft:spire"}}
+		(diamond|light blue) spire = - {"Trim": {"material": "minecraft:diamond", "pattern": "minecraft:spire"}}
+		(gold|yellow) spire = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:spire"}}
+		(iron|grey|gray) spire = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:spire"}}
+		(copper|brown) spire = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:spire"}}
+
+	{armor trims} leather (cap|helmet)¦s = minecraft:leather_helmet
+	{armor trims} leather (tunic|chest(piece|plate))¦s = minecraft:leather_chestplate
+	{armor trims} leather (pants|leggings) = minecraft:leather_leggings
+	{armor trims} leather boots = minecraft:leather_boots
+
+	{armor trims} iron (cap|helmet)¦s = minecraft:iron_helmet
+	{armor trims} iron chest(piece|plate)¦s = minecraft:iron_chestplate
+	{armor trims} iron (pants|leggings) = minecraft:iron_leggings
+	{armor trims} iron boots = minecraft:iron_boots
+
+	{armor trims} gold[en] (cap|helmet)¦s = minecraft:golden_helmet
+	{armor trims} gold[en] chest(piece|plate)¦s = minecraft:golden_chestplate
+	{armor trims} gold[en] (pants|leggings) = minecraft:golden_leggings
+	{armor trims} gold[en] boots = minecraft:golden_boots
+
+	{armor trims} diamond (cap|helmet)¦s = minecraft:diamond_helmet
+	{armor trims} diamond chest(piece|plate)¦s = minecraft:diamond_chestplate
+	{armor trims} diamond (pants|leggings) = minecraft:diamond_leggings
+	{armor trims} diamond boots = minecraft:diamond_boots
+
+	{armor trims} chain[mail] (cap|helmet)¦s = minecraft:chainmail_helmet
+	{armor trims} chain[mail] chest(piece|plate)¦s = minecraft:chainmail_chestplate
+	{armor trims} chain[mail] (pants|leggings) = minecraft:chainmail_leggings
+	{armor trims} chain[mail] boots = minecraft:chainmail_boots
+
+	{armor trims} netherite (cap|helmet)¦s = minecraft:netherite_helmet
+	{armor trims} netherite chest(piece|plate)¦s = minecraft:netherite_chestplate
+	{armor trims} netherite (pants|leggings) = minecraft:netherite_leggings
+	{armor trims} netherite boots = minecraft:netherite_boots

--- a/decoration.sk
+++ b/decoration.sk
@@ -818,3 +818,9 @@ trails and tales update:
 
 	[any] hanging sign¦s = oak hanging sign, oak wall hanging sign, birch hanging sign, birch wall hanging sign, jungle hanging sign, jungle wall hanging sign, spruce hanging sign, spruce wall hanging sign, acacia hanging sign, acacia wall hanging sign, dark oak hanging sign, dark oak wall hanging sign, mangrove hanging sign, mangrove wall hanging sign, cherry hanging sign, cherry wall hanging sign, bamboo hanging sign, bamboo wall hanging sign
 	[any] sign¦s = any sign, any hanging sign
+
+	piglin (head|skull) item¦s = minecraft:piglin_head
+	[any] (head|skull) item¦s = any skull item, piglin head item
+	[any] (head|skull)¦s = any skull item
+	{directional} piglin wall[-mounted] (skull|head)¦s = minecraft:piglin_wall_head
+	{reversed rotatable} piglin (head|skull)¦s = minecraft:piglin_head

--- a/decoration.sk
+++ b/decoration.sk
@@ -802,22 +802,22 @@ trails and tales update:
 		(dangling|attached|loose) = -[attached=true]
 	{waterloggable} {directional} {wood type} wall hanging sign¦s = -wall_hanging_sign
 	{waterloggable} {rotatable} {hanging sign attachment} {wood type} hanging sign¦s = -hanging_sign
-	[any] oak sign¦s = oak sign, oak hanging sign, oak wall hanging sign
-	[any] birch sign¦s = birch sign, birch hanging sign, birch wall hanging sign
-	[any] jungle sign¦s = jungle sign, jungle hanging sign, jungle wall hanging sign
-	[any] spruce sign¦s = spruce sign, spruce hanging sign, spruce wall hanging sign
-	[any] acacia sign¦s = acacia sign, acacia hanging sign, acacia wall hanging sign
-	[any] dark oak sign¦s = dark oak sign, dark oak hanging sign, dark oak wall hanging sign
-	[any] mangrove sign¦s = mangrove sign, mangrove hanging sign, mangrove wall hanging sign
+	#[any] oak sign¦s = oak sign, oak hanging sign, oak wall hanging sign
+	#[any] birch sign¦s = birch sign, birch hanging sign, birch wall hanging sign
+	#[any] jungle sign¦s = jungle sign, jungle hanging sign, jungle wall hanging sign
+	#[any] spruce sign¦s = spruce sign, spruce hanging sign, spruce wall hanging sign
+	#[any] acacia sign¦s = acacia sign, acacia hanging sign, acacia wall hanging sign
+	#[any] dark oak sign¦s = dark oak sign, dark oak hanging sign, dark oak wall hanging sign
+	#[any] mangrove sign¦s = mangrove sign, mangrove hanging sign, mangrove wall hanging sign
 
-	[any] cherry sign¦s = cherry floor sign, cherry wall sign, cherry hanging sign, cherry wall hanging sign
-	[any] bamboo sign¦s = bamboo floor sign, bamboo wall sign, bamboo hanging sign, bamboo wall hanging sign
+	[any] cherry sign¦s = cherry floor sign, cherry wall sign#, cherry hanging sign, cherry wall hanging sign
+	[any] bamboo sign¦s = bamboo floor sign, bamboo wall sign#, bamboo hanging sign, bamboo wall hanging sign
 
 	[any] wall hanging sign¦s = oak wall hanging sign, birch wall hanging sign, jungle wall hanging sign, spruce wall hanging sign, acacia wall hanging sign, dark oak wall hanging sign, mangrove wall hanging sign, cherry wall hanging sign, bamboo wall hanging sign
 	[any] wall sign¦s = wall sign, wall hanging sign
 
 	[any] hanging sign¦s = oak hanging sign, oak wall hanging sign, birch hanging sign, birch wall hanging sign, jungle hanging sign, jungle wall hanging sign, spruce hanging sign, spruce wall hanging sign, acacia hanging sign, acacia wall hanging sign, dark oak hanging sign, dark oak wall hanging sign, mangrove hanging sign, mangrove wall hanging sign, cherry hanging sign, cherry wall hanging sign, bamboo hanging sign, bamboo wall hanging sign
-	[any] sign¦s = any sign, any hanging sign
+	[any] sign¦s = any sign, any wall sign, any hanging sign
 
 	piglin (head|skull) item¦s = minecraft:piglin_head
 	[any] (head|skull) item¦s = any skull item, piglin head item

--- a/decoration.sk
+++ b/decoration.sk
@@ -778,3 +778,20 @@ the wild update:
 
 	# sculk stuffs
 	{waterloggable} {surface} sculk vein¦s = minecraft:sculk_vein
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	[any] sapling¦s = any sapling, cherry sapling
+	[any] lea(f|ves) = any leaves, cherry leaves
+
+	{flower amount}:
+		{default} = -
+		with (one|1) flower = -[flower_amount=1]
+		with (two|2) flowers = -[flower_amount=2]
+		with (three|3) flowers = -[flower_amount=3]
+		with (four|all|4) flowers = -[flower_amount=4]
+	pink petals¦s {flower amount} = minecraft:pink_petals
+
+	torch flower¦s = minecraft:torchflower
+	{block half} pitcher plant¦s = minecraft:pitcher_plant

--- a/decoration.sk
+++ b/decoration.sk
@@ -795,3 +795,26 @@ trails and tales update:
 
 	torch flower¦s = minecraft:torchflower
 	{block half} pitcher plant¦s = minecraft:pitcher_plant
+
+	{hanging sign attachment}:
+		{default} = -
+		(not attached|straight) = -[attached=false]
+		(dangling|attached|loose) = -[attached=true]
+	{waterloggable} {directional} {wood type} wall hanging sign¦s = -wall_hanging_sign
+	{waterloggable} {rotatable} {hanging sign attachment} {wood type} hanging sign¦s = -hanging_sign
+	[any] oak sign¦s = oak sign, oak hanging sign, oak wall hanging sign
+	[any] birch sign¦s = birch sign, birch hanging sign, birch wall hanging sign
+	[any] jungle sign¦s = jungle sign, jungle hanging sign, jungle wall hanging sign
+	[any] spruce sign¦s = spruce sign, spruce hanging sign, spruce wall hanging sign
+	[any] acacia sign¦s = acacia sign, acacia hanging sign, acacia wall hanging sign
+	[any] dark oak sign¦s = dark oak sign, dark oak hanging sign, dark oak wall hanging sign
+	[any] mangrove sign¦s = mangrove sign, mangrove hanging sign, mangrove wall hanging sign
+
+	[any] cherry sign¦s = cherry floor sign, cherry wall sign, cherry hanging sign, cherry wall hanging sign
+	[any] bamboo sign¦s = bamboo floor sign, bamboo wall sign, bamboo hanging sign, bamboo wall hanging sign
+
+	[any] wall hanging sign¦s = oak wall hanging sign, birch wall hanging sign, jungle wall hanging sign, spruce wall hanging sign, acacia wall hanging sign, dark oak wall hanging sign, mangrove wall hanging sign, cherry wall hanging sign, bamboo wall hanging sign
+	[any] wall sign¦s = wall sign, wall hanging sign
+
+	[any] hanging sign¦s = oak hanging sign, oak wall hanging sign, birch hanging sign, birch wall hanging sign, jungle hanging sign, jungle wall hanging sign, spruce hanging sign, spruce wall hanging sign, acacia hanging sign, acacia wall hanging sign, dark oak hanging sign, dark oak wall hanging sign, mangrove hanging sign, mangrove wall hanging sign, cherry hanging sign, cherry wall hanging sign, bamboo hanging sign, bamboo wall hanging sign
+	[any] sign¦s = any sign, any hanging sign

--- a/misc-eggs.sk
+++ b/misc-eggs.sk
@@ -182,3 +182,9 @@ the wild update:
 	(tadpole [spawn] egg|spawn tadpole)¦s = minecraft:tadpole_spawn_egg
 	(warden [spawn] egg|spawn warden)¦s = minecraft:warden_spawn_egg
 	[any] spawn egg¦s = any spawn egg, spawn allay, spawn frog, spawn tadpole, spawn warden
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+	(camel [spawn] egg|spawn camel)¦s = minecraft:camel_spawn_egg
+	(sniffer [spawn] egg|spawn sniffer)¦s = minecraft:sniffer_spawn_egg
+	[any] spawn egg¦s = any spawn egg, spawn camel, spawn sniffer

--- a/misc.sk
+++ b/misc.sk
@@ -367,3 +367,27 @@ trails and tales update:
 	minecraft version = 1.20 or newer
 
 	brush¦es = minecraft:brush
+	[music] (disc|record) relic = minecraft:music_disc_relic
+	[any] [music] (disc|record) = any music disc, music disc relic
+
+	angler pottery sherd¦s = minecraft:angler_pottery_sherd
+	archer pottery sherd¦s = minecraft:archer_pottery_sherd
+	arms up pottery sherd¦s = minecraft:arms_up_pottery_sherd
+	blade pottery sherd¦s = minecraft:blade_pottery_sherd
+	brewer pottery sherd¦s = minecraft:brewer_pottery_sherd
+	burn pottery sherd¦s = minecraft:burn_pottery_sherd
+	danger pottery sherd¦s = minecraft:danger_pottery_sherd
+	explorer pottery sherd¦s = minecraft:explorer_pottery_sherd
+	friend pottery sherd¦s = minecraft:friend_pottery_sherd
+	heart pottery sherd¦s = minecraft:heart_pottery_sherd
+	heart[ ]break pottery sherd¦s = minecraft:heartbreak_pottery_sherd
+	howl pottery sherd¦s = minecraft:howl_pottery_sherd
+	miner pottery sherd¦s = minecraft:miner_pottery_sherd
+	mourner pottery sherd¦s = minecraft:mourner_pottery_sherd
+	plenty pottery sherd¦s = minecraft:plenty_pottery_sherd
+	prize pottery sherd¦s = minecraft:prize_pottery_sherd
+	sheaf pottery sherd¦s = minecraft:sheaf_pottery_sherd
+	shelter pottery sherd¦s = minecraft:shelter_pottery_sherd
+	snort pottery sherd¦s = minecraft:snort_pottery_sherd
+	skull pottery sherd¦s = minecraft:skull_pottery_sherd
+	[any] pottery sherd¦s = angler pottery sherd, archer pottery sherd, arms up pottery sherd, blade pottery sherd, brewer pottery sherd, burn pottery sherd, danger pottery sherd, explorer pottery sherd, friend pottery sherd, heart pottery sherd, heartbreak pottery sherd, howl pottery sherd, miner pottery sherd, mourner pottery sherd, plenty pottery sherd, prize pottery sherd, sheaf pottery sherd, shelter pottery sherd, snort pottery sherd, skull pottery sherd

--- a/misc.sk
+++ b/misc.sk
@@ -391,3 +391,21 @@ trails and tales update:
 	snort pottery sherd¦s = minecraft:snort_pottery_sherd
 	skull pottery sherd¦s = minecraft:skull_pottery_sherd
 	[any] pottery sherd¦s = angler pottery sherd, archer pottery sherd, arms up pottery sherd, blade pottery sherd, brewer pottery sherd, burn pottery sherd, danger pottery sherd, explorer pottery sherd, friend pottery sherd, heart pottery sherd, heartbreak pottery sherd, howl pottery sherd, miner pottery sherd, mourner pottery sherd, plenty pottery sherd, prize pottery sherd, sheaf pottery sherd, shelter pottery sherd, snort pottery sherd, skull pottery sherd
+
+	pitcher pod¦s = minecraft:pitcher_pod
+
+	{sniffer egg hatches}:
+		{default} = -
+		(stage 1|hatch 0) = -[hatch=0]
+		(stage 2|hatch 1) = -[hatch=1]
+		(stage 3|hatch 2) = -[hatch=2]
+	{sniffer egg hatches} sniffer egg¦s = minecraft:sniffer_egg
+
+	{dusted}:
+		{default} = -
+		(stage 1|dusted 0) = -[dusted=0]
+		(stage 2|dusted 1) = -[dusted=1]
+		(stage 3|dusted 2) = -[dusted=2]
+		(stage 4|dusted 3) = -[dusted=3]
+	{dusted} suspicious sand¦s = minecraft:suspicious_sand
+	{dusted} suspicious gravel¦s = minecraft:suspicious_gravel

--- a/misc.sk
+++ b/misc.sk
@@ -363,3 +363,7 @@ the wild update:
 		
 	{horn variations} goat horn¦s = minecraft:goat_horn
 	
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	brush¦es = minecraft:brush

--- a/redstone.sk
+++ b/redstone.sk
@@ -294,23 +294,26 @@ the wild update:
 trails and tales update:
 	minecraft version = 1.20 or newer
 
-	{powerable} {directional} {attached} cherry button¦s = minecraft:cherry_button
+	# Cherry wood
 	[any] wood[en] button¦s = wood button, cherry button
 	[any] button¦s = any button, cherry button
-
-	{powerable} cherry button¦s = minecraft:cherry_pressure_plate
 	[any] pressure plate¦s = pressure plate, cherry pressure plate
-	[any] wood[en] pressure plate¦s = any wooden pressure plate, cherry pressure plate
-
-	{gate state} cherry [wood] [fence] gate¦s = minecraft:cherry_fence_gate
 	[any] [fence] gate¦s = gate, cherry gate
-
-	{waterloggable} {openable} {trapdoor position} {directional} cherry trapdoor¦s = minecraft:cherry_trapdoor
 	[any] wood[en] trapdoor¦s = wood trapdoor, cherry trapdoor
 	[any] trapdoor¦s = any trapdoor, cherry trapdoor
-
-	{door state} cherry [wood] door¦s = minecraft:cherry_door
 	[any] wood[en] door¦s = any wood door, cherry door
 	[any] door¦s = any door, cherry door
-
 	[any] fence¦s = any fence, cherry fence
+	[any] wood[en] pressure plate¦s = any wooden pressure plate, cherry pressure plate
+
+	# Bamboo wood
+	[any] wood[en] button¦s = wood button, bamboo button
+	[any] button¦s = any button, bamboo button
+	[any] pressure plate¦s = pressure plate, bamboo pressure plate
+	[any] [fence] gate¦s = gate, bamboo gate
+	[any] wood[en] trapdoor¦s = wood trapdoor, bamboo trapdoor
+	[any] trapdoor¦s = any trapdoor, bamboo trapdoor
+	[any] wood[en] door¦s = any wood door, bamboo door
+	[any] door¦s = any door, bamboo door
+	[any] fence¦s = any fence, bamboo fence
+	[any] wood[en] pressure plate¦s = any wooden pressure plate, bamboo pressure plate

--- a/redstone.sk
+++ b/redstone.sk
@@ -290,3 +290,27 @@ the wild update:
 	[any] door¦s = any door, mangrove door
 	[any] fence¦s = any fence, mangrove fence
 	[any] wood[en] pressure plate¦s = any wooden pressure plate, mangrove pressure plate
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	{powerable} {directional} {attached} cherry button¦s = minecraft:cherry_button
+	[any] wood[en] button¦s = wood button, cherry button
+	[any] button¦s = any button, cherry button
+
+	{powerable} cherry button¦s = minecraft:cherry_pressure_plate
+	[any] pressure plate¦s = pressure plate, cherry pressure plate
+	[any] wood[en] pressure plate¦s = any wooden pressure plate, cherry pressure plate
+
+	{gate state} cherry [wood] [fence] gate¦s = minecraft:cherry_fence_gate
+	[any] [fence] gate¦s = gate, cherry gate
+
+	{waterloggable} {openable} {trapdoor position} {directional} cherry trapdoor¦s = minecraft:cherry_trapdoor
+	[any] wood[en] trapdoor¦s = wood trapdoor, cherry trapdoor
+	[any] trapdoor¦s = any trapdoor, cherry trapdoor
+
+	{door state} cherry [wood] door¦s = minecraft:cherry_door
+	[any] wood[en] door¦s = any wood door, cherry door
+	[any] door¦s = any door, cherry door
+
+	[any] fence¦s = any fence, cherry fence

--- a/transportation.sk
+++ b/transportation.sk
@@ -121,22 +121,35 @@ the wild update:
 	minecraft version = 1.19 or newer
 
 	# boat with chest
-	spruce (chest boat¦s|boat¦s with chest) = minecraft:spruce_chest_boat[relatedEntity=spruce chest boat]
+	spruce (boat¦s with chest|chest boat¦s) = minecraft:spruce_chest_boat[relatedEntity=spruce chest boat]
 	any spruce boat¦s = spruce boat, spruce chest boat
-	birch (chest boat¦s|boat¦s with chest) = minecraft:birch_chest_boat[relatedEntity=birch chest boat]
+	birch (boat¦s with chest|chest boat¦s) = minecraft:birch_chest_boat[relatedEntity=birch chest boat]
 	any birch boat¦s = birch boat, birch chest boat
-	jungle (chest boat¦s|boat¦s with chest) = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
+	jungle (boat¦s with chest|chest boat¦s) = minecraft:jungle_chest_boat[relatedEntity=jungle chest boat]
 	any jungle boat¦s = jungle boat, jungle chest boat
-	acacia (chest boat¦s|boat¦s with chest) = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
+	acacia (boat¦s with chest|chest boat¦s) = minecraft:acacia_chest_boat[relatedEntity=acacia chest boat]
 	any acacia boat¦s = acacia boat, acacia chest boat
-	oak (chest boat¦s|boat¦s with chest) = minecraft:oak_chest_boat[relatedEntity=oak chest boat]
+	oak (boat¦s with chest|chest boat¦s) = minecraft:oak_chest_boat[relatedEntity=oak chest boat]
 	any oak boat¦s = oak boat, oak chest boat
-	dark oak (chest boat¦s|boat¦s with chest) = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
+	dark oak (boat¦s with chest|chest boat¦s) = minecraft:dark_oak_chest_boat[relatedEntity=dark oak chest boat]
 	any dark oak boat¦s = dark oak boat, dark oak chest boat
 
 	mangrove boat¦s = minecraft:mangrove_boat[relatedEntity=mangrove boat]
-	mangrove (chest boat¦s|boat¦s with chest) = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
+	mangrove (boat¦s with chest|chest boat¦s) = minecraft:mangrove_chest_boat[relatedEntity=mangrove chest boat]
 	any mangrove boat¦s = mangrove boat, mangrove chest boat
 
-	[any] (chest[ed] boat¦s|boat¦s with [a] chest) = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
+	[any] (boat¦s with [a] chest|chest[ed] boat¦s) = spruce chest boat, birch chest boat, jungle chest boat, acacia chest boat, dark oak chest boat, mangrove chest boat
 	[any] boat = any boat, chested boat, any mangrove boat
+
+trails and tales update:
+	minecraft version = 1.20 or newer
+
+	cherry boat¦s = minecraft:cherry_boat[relatedEntity=cherry boat]
+	cherry (boat¦s with chest|chest boat¦s) = minecraft:cherry_chest_boat[relatedEntity=cherry chest boat]
+	any cherry boat¦s = cherry boat, cherry chest boat
+	bamboo (boat|raft)¦s = minecraft:bamboo_raft[relatedEntity=bamboo raft]
+	bamboo ((boat|raft)¦s with chest|chest (boat|raft)¦s) = minecraft:bamboo_chest_raft[relatedEntity=bamboo chest raft]
+	any bamboo (boat|raft)¦s = bamboo raft, bamboo chest raft
+
+	[any] (boat¦s with [a] chest|chest[ed] boat¦s) = any chest boat, cherry chest boat, bamboo chest raft
+	[any] boat = any boat, any cherry boat, any bamboo raft


### PR DESCRIPTION
Aliases for 1.20, optimized for the easiest understanding and most flexibility.

Each item individually tested and ensured for picking understand-ability like how `any wall sign` should equal any normal wall sign and any wall hanging sign.

Notes
- that mangrove cannot be a tree type because it's saplings are named different and bamboo cannot be a tree type because it has no logs.
- bamboo has MOZAIC as a different block in the set.
- Moved stair variation properties to the globalvariation file for proper usage.