### PR TITLE
Fix lantern not working

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -655,7 +655,7 @@ nether update:
 	any campfire = campfire, soul campfire
 
 	{lantern hanging} soul lantern¦s = minecraft:soul_lantern
-	any lantern = lantern, soul lantern
+	[any] lantern = lantern, soul lantern
 
 	[any] crimson sign¦s = crimson floor sign, crimson wall sign
 	[any] warped sign¦s = warped floor sign, warped wall sign


### PR DESCRIPTION
Fix lantern not working. `on place of lantern` does not work, you had to use `any lantern` to fix that issue.