### PR TITLE
Add hanging signs to the sign category

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -802,16 +802,16 @@ trails and tales update:
 		(dangling|attached|loose) = -[attached=true]
 	{waterloggable} {directional} {wood type} wall hanging sign¦s = -wall_hanging_sign
 	{waterloggable} {rotatable} {hanging sign attachment} {wood type} hanging sign¦s = -hanging_sign
-	#[any] oak sign¦s = oak sign, oak hanging sign, oak wall hanging sign
-	#[any] birch sign¦s = birch sign, birch hanging sign, birch wall hanging sign
-	#[any] jungle sign¦s = jungle sign, jungle hanging sign, jungle wall hanging sign
-	#[any] spruce sign¦s = spruce sign, spruce hanging sign, spruce wall hanging sign
-	#[any] acacia sign¦s = acacia sign, acacia hanging sign, acacia wall hanging sign
-	#[any] dark oak sign¦s = dark oak sign, dark oak hanging sign, dark oak wall hanging sign
-	#[any] mangrove sign¦s = mangrove sign, mangrove hanging sign, mangrove wall hanging sign
+	[any] oak sign¦s = oak sign, oak hanging sign, oak wall hanging sign
+	[any] birch sign¦s = birch sign, birch hanging sign, birch wall hanging sign
+	[any] jungle sign¦s = jungle sign, jungle hanging sign, jungle wall hanging sign
+	[any] spruce sign¦s = spruce sign, spruce hanging sign, spruce wall hanging sign
+	[any] acacia sign¦s = acacia sign, acacia hanging sign, acacia wall hanging sign
+	[any] dark oak sign¦s = dark oak sign, dark oak hanging sign, dark oak wall hanging sign
+	[any] mangrove sign¦s = mangrove sign, mangrove hanging sign, mangrove wall hanging sign
 
-	[any] cherry sign¦s = cherry floor sign, cherry wall sign#, cherry hanging sign, cherry wall hanging sign
-	[any] bamboo sign¦s = bamboo floor sign, bamboo wall sign#, bamboo hanging sign, bamboo wall hanging sign
+	[any] cherry sign¦s = cherry floor sign, cherry wall sign, cherry hanging sign, cherry wall hanging sign
+	[any] bamboo sign¦s = bamboo floor sign, bamboo wall sign, bamboo hanging sign, bamboo wall hanging sign
 
 	[any] wall hanging sign¦s = oak wall hanging sign, birch wall hanging sign, jungle wall hanging sign, spruce wall hanging sign, acacia wall hanging sign, dark oak wall hanging sign, mangrove wall hanging sign, cherry wall hanging sign, bamboo wall hanging sign
 	[any] wall sign¦s = wall sign, wall hanging sign


### PR DESCRIPTION
`any oak sign` should reflect any sign regardless of it's placement, as long as it's an oak sign, it will fall under the oak sign category.