### PR TITLE
Fix Aliases For 1.20.5/1.20.6

### DIFF
--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -357,3 +357,131 @@ wild-update woods:
 		acacia = minecraft:acacia_-
 		dark oak = minecraft:dark_oak_-
 		cherry = minecraft:cherry_-
+
+potions before components:
+	minecraft version = 1.20.4 or older
+
+	{potion types}:
+		{default} = - # Match all potions
+		water = - {"Potion": "minecraft:water"}
+		thick = - {"Potion": "minecraft:thick"}
+		mundane = - {"Potion": "minecraft:mundane"}
+		awkward = - {"Potion": "minecraft:awkward"}
+
+		night vision = - {"Potion": "minecraft:night_vision"}
+		(long|extended) night vision = - {"Potion": "minecraft:long_night_vision"}
+
+		invisibility = - {"Potion": "minecraft:invisibility"}
+		(long|extended) invisibility = - {"Potion": "minecraft:long_invisibility"}
+
+		(leaping|jumping) = - {"Potion": "minecraft:leaping"}
+		(long|extended) (leaping|jumping) = - {"Potion": "minecraft:long_leaping"}
+		(strong|upgraded|level 2) (leaping|jumping) = - {"Potion": "minecraft:strong_leaping"}
+
+		fire resistance = - {"Potion": "minecraft:fire_resistance"}
+		(long|extended) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
+
+		(swiftness|speed) = - {"Potion": "minecraft:swiftness"}
+		(extended|long) (speed|swiftness) = - {"Potion": "minecraft:long_swiftness"}
+		(strong|upgraded|level 2) (speed|swiftness) = - {"Potion": "minecraft:strong_swiftness"}
+
+		slow[ness] = - {"Potion": "minecraft:slowness"}
+		(long|extended) slow[ness] = - {"Potion": "minecraft:long_slowness"}
+		(strong|upgraded|level 2) slow[ness] = - {"Potion": "minecraft:strong_slowness"}
+
+		water breathing = - {"Potion": "minecraft:water_breathing"}
+		(long|extended) water breathing = - {"Potion": "minecraft:long_water_breathing"}
+
+		[instant] heal(th|ing) = - {"Potion": "minecraft:healing"}
+		(strong|upgraded|level 2) [instant] heal(th|ing) = - {"Potion": "minecraft:strong_healing"}
+
+		[instant] (harming|damage) = - {"Potion": "minecraft:harming"}
+		(strong|upgraded|level 2) [instant] (harming|damage) = - {"Potion": "minecraft:strong_harming"}
+
+		poison[ing] = - {"Potion": "minecraft:poison"}
+		(long|extended) poison[ing] = - {"Potion": "minecraft:long_poison"}
+		(strong|upgraded|level 2) poison[ing] = - {"Potion": "minecraft:strong_poison"}
+
+		regen[eration] = - {"Potion": "minecraft:regeneration"}
+		(long|extended) regen[eration] = - {"Potion": "minecraft:long_regeneration"}
+		(strong|upgraded|level 2) regen[eration] = - {"Potion": "minecraft:strong_regeneration"}
+
+		strength = - {"Potion": "minecraft:strength"}
+		(long|extended) strength = - {"Potion": "minecraft:long_strength"}
+		(strong|upgraded|level 2) strength = - {"Potion": "minecraft:strong_strength"}
+
+		weak(ness|ening) = - {"Potion": "minecraft:weakness"}
+		(long|extended) weak(ness|ening) = - {"Potion": "minecraft:long_weakness"}
+
+		luck = - {"Potion": "minecraft:luck"}
+
+		turtle master = - {"Potion": "minecraft:turtle_master"}
+		(long|extended) turtle master = - {"Potion": "minecraft:long_turtle_master"}
+		(strong|upgraded|level 2) turtle master = - {"Potion": "minecraft:strong_turtle_master"}
+
+		slow fall[ing] = - {"Potion": "minecraft:slow_falling"}
+		(long|extended) slow fall[ing] = - {"Potion": "minecraft:long_slow_falling"}
+
+potions after components:
+	minecraft version = 1.20.5 or newer
+
+	{potion types}:
+		{default} = - # Match all potions
+		water = - {minecraft:potion_contents={"potion":"minecraft:water"}}
+		thick = - {minecraft:potion_contents={"potion":"minecraft:thick"}}
+		mundane = - {minecraft:potion_contents={"potion":"minecraft:mundane"}}
+		awkward = - {minecraft:potion_contents={"potion":"minecraft:awkward"}}
+
+		night vision = - {minecraft:potion_contents={"potion":"minecraft:night_vision"}}
+		(long|extended) night vision = - {minecraft:potion_contents={"potion":"minecraft:long_night_vision"}}
+
+		invisibility = - {minecraft:potion_contents={"potion":"minecraft:invisibility"}}
+		(long|extended) invisibility = - {minecraft:potion_contents={"potion":"minecraft:long_invisibility"}}
+
+		(leaping|jumping) = - {minecraft:potion_contents={"potion":"minecraft:leaping"}}
+		(long|extended) (leaping|jumping) = - {minecraft:potion_contents={"potion":"minecraft:long_leaping"}}
+		(strong|upgraded|level 2) (leaping|jumping) = - {minecraft:potion_contents={"potion":"minecraft:strong_leaping"}}
+
+		fire resistance = - {minecraft:potion_contents={"potion":"minecraft:fire_resistance"}}
+		(long|extended) fire resistance = - {minecraft:potion_contents={"potion":"minecraft:long_fire_resistance"}}
+
+		(swiftness|speed) = - {minecraft:potion_contents={"potion":"minecraft:swiftness"}}
+		(extended|long) (speed|swiftness) = - {minecraft:potion_contents={"potion":"minecraft:long_swiftness"}}
+		(strong|upgraded|level 2) (speed|swiftness) = - {minecraft:potion_contents={"potion":"minecraft:strong_swiftness"}}
+
+		slow[ness] = - {minecraft:potion_contents={"potion":"minecraft:slowness"}}
+		(long|extended) slow[ness] = - {minecraft:potion_contents={"potion":"minecraft:long_slowness"}}
+		(strong|upgraded|level 2) slow[ness] = - {minecraft:potion_contents={"potion":"minecraft:strong_slowness"}}
+
+		water breathing = - {minecraft:potion_contents={"potion":"minecraft:water_breathing"}}
+		(long|extended) water breathing = - {minecraft:potion_contents={"potion":"minecraft:long_water_breathing"}}
+
+		[instant] heal(th|ing) = - {minecraft:potion_contents={"potion":"minecraft:healing"}}
+		(strong|upgraded|level 2) [instant] heal(th|ing) = - {minecraft:potion_contents={"potion":"minecraft:strong_healing"}}
+
+		[instant] (harming|damage) = - {minecraft:potion_contents={"potion":"minecraft:harming"}}
+		(strong|upgraded|level 2) [instant] (harming|damage) = - {minecraft:potion_contents={"potion":"minecraft:strong_harming"}}
+
+		poison[ing] = - {minecraft:potion_contents={"potion":"minecraft:poison"}}
+		(long|extended) poison[ing] = - {minecraft:potion_contents={"potion":"minecraft:long_poison"}}
+		(strong|upgraded|level 2) poison[ing] = - {minecraft:potion_contents={"potion":"minecraft:strong_poison"}}
+
+		regen[eration] = - {minecraft:potion_contents={"potion":"minecraft:regeneration"}}
+		(long|extended) regen[eration] = - {minecraft:potion_contents={"potion":"minecraft:long_regeneration"}}
+		(strong|upgraded|level 2) regen[eration] = - {minecraft:potion_contents={"potion":"minecraft:strong_regeneration"}}
+
+		strength = - {minecraft:potion_contents={"potion":"minecraft:strength"}}
+		(long|extended) strength = - {minecraft:potion_contents={"potion":"minecraft:long_strength"}}
+		(strong|upgraded|level 2) strength = - {minecraft:potion_contents={"potion":"minecraft:strong_strength"}}
+
+		weak(ness|ening) = - {minecraft:potion_contents={"potion":"minecraft:weakness"}}
+		(long|extended) weak(ness|ening) = - {minecraft:potion_contents={"potion":"minecraft:long_weakness"}}
+
+		luck = - {minecraft:potion_contents={"potion":"minecraft:luck"}}
+
+		turtle master = - {minecraft:potion_contents={"potion":"minecraft:turtle_master"}}
+		(long|extended) turtle master = - {minecraft:potion_contents={"potion":"minecraft:long_turtle_master"}}
+		(strong|upgraded|level 2) turtle master = - {minecraft:potion_contents={"potion":"minecraft:strong_turtle_master"}}
+
+		slow fall[ing] = - {minecraft:potion_contents={"potion":"minecraft:slow_falling"}}
+		(long|extended) slow fall[ing] = - {minecraft:potion_contents={"potion":"minecraft:long_slow_falling"}}

--- a/+global-variations.sk
+++ b/+global-variations.sk
@@ -382,8 +382,8 @@ potions before components:
 		(long|extended) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
 
 		(swiftness|speed) = - {"Potion": "minecraft:swiftness"}
-		(extended|long) (speed|swiftness) = - {"Potion": "minecraft:long_swiftness"}
-		(strong|upgraded|level 2) (speed|swiftness) = - {"Potion": "minecraft:strong_swiftness"}
+		(extended|long) (swiftness|speed) = - {"Potion": "minecraft:long_swiftness"}
+		(strong|upgraded|level 2) (swiftness|speed) = - {"Potion": "minecraft:strong_swiftness"}
 
 		slow[ness] = - {"Potion": "minecraft:slowness"}
 		(long|extended) slow[ness] = - {"Potion": "minecraft:long_slowness"}
@@ -446,8 +446,8 @@ potions after components:
 		(long|extended) fire resistance = - {minecraft:potion_contents={"potion":"minecraft:long_fire_resistance"}}
 
 		(swiftness|speed) = - {minecraft:potion_contents={"potion":"minecraft:swiftness"}}
-		(extended|long) (speed|swiftness) = - {minecraft:potion_contents={"potion":"minecraft:long_swiftness"}}
-		(strong|upgraded|level 2) (speed|swiftness) = - {minecraft:potion_contents={"potion":"minecraft:strong_swiftness"}}
+		(extended|long) (swiftness|speed) = - {minecraft:potion_contents={"potion":"minecraft:long_swiftness"}}
+		(strong|upgraded|level 2) (swiftness|speed) = - {minecraft:potion_contents={"potion":"minecraft:strong_swiftness"}}
 
 		slow[ness] = - {minecraft:potion_contents={"potion":"minecraft:slowness"}}
 		(long|extended) slow[ness] = - {minecraft:potion_contents={"potion":"minecraft:long_slowness"}}

--- a/brewing.sk
+++ b/brewing.sk
@@ -3,15 +3,15 @@ potions:
 
 	dragon['s] breath = minecraft:dragon_breath
 
-	(potion[s] of {potion types}|{potion types} potion¦s) = minecraft:potion
-	(splash potion[s] of {potion types}|{potion types} splash potion¦s) = minecraft:splash_potion
-	(lingering potion[s] of {potion types}|{potion types} lingering potion¦s) = minecraft:lingering_potion
+	(potion¦s of {potion types}|{potion types} potion¦s) = minecraft:potion
+	(splash potion¦s of {potion types}|{potion types} splash potion¦s) = minecraft:splash_potion
+	(lingering potion¦s of {potion types}|{potion types} lingering potion¦s) = minecraft:lingering_potion
 	
-	(bottle[s] of water|water bottle¦s) = potion of water
+	(bottle¦s of water|water bottle¦s) = potion of water
 
-	potion = minecraft:potion
-	[any] splash potion = minecraft:splash_potion
-	[any] lingering potion = minecraft:lingering_potion
+	potion¦s = minecraft:potion
+	[any] splash potion¦s = minecraft:splash_potion
+	[any] lingering potion¦s = minecraft:lingering_potion
 	any potion = potion, any splash potion, any lingering potion
 
 blocks unchanged:

--- a/brewing.sk
+++ b/brewing.sk
@@ -1,69 +1,14 @@
 potions:
 	[(glass|empty)] bottle¦s = minecraft:glass_bottle
-	(bottle[s] of water|water bottle¦s) = minecraft:potion {"Potion": "minecraft:water"}
 
-	{potion types}:
-		{default} = - # Match all potions
-		water = - {"Potion": "minecraft:water"}
-		thick = - {"Potion": "minecraft:thick"}
-		mundane = - {"Potion": "minecraft:mundane"}
-		awkward = - {"Potion": "minecraft:awkward"}
-
-		night vision = - {"Potion": "minecraft:night_vision"}
-		(extended|long) night vision = - {"Potion": "minecraft:long_night_vision"}
-
-		invisibility = - {"Potion": "minecraft:invisibility"}
-		(extended|long) invisibility = - {"Potion": "minecraft:long_invisibility"}
-
-		(leaping|jumping) = - {"Potion": "minecraft:leaping"}
-		(extended|long) (leaping|jumping) = - {"Potion": "minecraft:long_leaping"}
-		(strong|upgraded|level 2) (leaping|jumping) = - {"Potion": "minecraft:strong_leaping"}
-
-		fire resistance = - {"Potion": "minecraft:fire_resistance"}
-		(extended|long) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
-
-		(speed|swiftness) = - {"Potion": "minecraft:swiftness"}
-		(extended|long) (speed|swiftness) = - {"Potion": "minecraft:long_swiftness"}
-		(strong|upgraded|level 2) (speed|swiftness) = - {"Potion": "minecraft:strong_swiftness"}
-
-		slow[ness] = - {"Potion": "minecraft:slowness"}
-		(extended|long) slow[ness] = - {"Potion": "minecraft:long_slowness"}
-		(strong|upgraded|level 2) slow[ness] = - {"Potion": "minecraft:strong_slowness"}
-
-		turtle master = - {"Potion": "minecraft:turtle_master"}
-		(extended|long) turtle master = - {"Potion": "minecraft:long_turtle_master"}
-		(strong|upgraded|level 2) turtle master = - {"Potion": "minecraft:strong_turtle_master"}
-
-		water breathing = - {"Potion": "minecraft:water_breathing"}
-		(extended|long) water breathing = - {"Potion": "minecraft:long_water_breathing"}
-
-		heal(th|ing) = - {"Potion": "minecraft:healing"}
-		(strong|upgraded|level 2) heal(th|ing) = - {"Potion": "minecraft:strong_healing"}
-
-		harming = - {"Potion": "minecraft:harming"}
-		(strong|upgraded|level 2) harming = - {"Potion": "minecraft:strong_harming"}
-
-		poison[ing] = - {"Potion": "minecraft:poison"}
-		(extended|long) poison[ing] = - {"Potion": "minecraft:long_poison"}
-		(strong|upgraded|level 2) poison[ing] = - {"Potion": "minecraft:strong_poison"}
-
-		regen[eration] = - {"Potion": "minecraft:regeneration"}
-		(extended|long) regen[eration] = - {"Potion": "minecraft:long_regeneration"}
-		(strong|upgraded|level 2) regen[eration] = - {"Potion": "minecraft:strong_regeneration"}
-
-		strength = - {"Potion": "minecraft:strength"}
-		(extended|long) strength = - {"Potion": "minecraft:long_strength"}
-		(strong|upgraded|level 2) strength = - {"Potion": "minecraft:strong_strength"}
-
-		weak(ness|ening) = - {"Potion": "minecraft:weakness"}
-		(extended|long) weak(ness|ening) = - {"Potion": "minecraft:long_weakness"}
-
-		slow fall[ing] = - {"Potion": "minecraft:slow_falling"}
-		(extended|long) slow fall[ing] = - {"Potion": "minecraft:long_slow_falling"}
+	dragon['s] breath = minecraft:dragon_breath
 
 	(potion[s] of {potion types}|{potion types} potion¦s) = minecraft:potion
 	(splash potion[s] of {potion types}|{potion types} splash potion¦s) = minecraft:splash_potion
 	(lingering potion[s] of {potion types}|{potion types} lingering potion¦s) = minecraft:lingering_potion
+	
+	(bottle[s] of water|water bottle¦s) = potion of water
+
 	potion = minecraft:potion
 	[any] splash potion = minecraft:splash_potion
 	[any] lingering potion = minecraft:lingering_potion
@@ -96,18 +41,6 @@ blocks after caves and cliffs update part 1:
 		(filled|full) = -[level=3]
 	{cauldron level} [water] cauldron¦s = minecraft:water_cauldron # "water" is optional for backwards compatibility
 	{cauldron level} powder snow cauldron¦s = minecraft:powder_snow_cauldron
-	
-
-combat update brewing:
-	minecraft version = 1.9 or newer
-	dragon['s] breath = minecraft:dragon_breath
-
-	{combat update potions}:
-		luck = - {"Potion": "minecraft:luck"}
-
-	(potion[s] of {combat update potions}|{combat update potions} potion¦s) = minecraft:potion
-	(splash potion[s] of {combat update potions}|{combat update potions} splash potion¦s) = minecraft:splash_potion
-	(lingering potion[s] of {combat update potions}|{combat update potions} lingering potion¦s) = minecraft:lingering_potion
 
 unchanged ingredients:
 	ghast tear¦s = minecraft:ghast_tear

--- a/combat.sk
+++ b/combat.sk
@@ -510,6 +510,7 @@ armor trims after components:
 		(iron|grey|gray) spire = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:spire"}}
 		(copper|brown) spire = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:spire"}}
 armor trims:
+	minecraft version = 1.20 or newer
 	{armor trims} leather (cap|helmet)¦s = minecraft:leather_helmet
 	{armor trims} leather (tunic|chest(piece|plate))¦s = minecraft:leather_chestplate
 	{armor trims} leather (pants|leggings) = minecraft:leather_leggings

--- a/combat.sk
+++ b/combat.sk
@@ -2,45 +2,9 @@ combat update:
 	minecraft version = 1.9 or newer
 	shield¦s = minecraft:shield
 
-	{tipped arrow types}:
-		{default} = -
-		night vision = - {"Potion": "minecraft:night_vision"}
-		(long|extended) night vision = - {"Potion": "minecraft:long_night_vision"}
-		invisibility = - {"Potion": "minecraft:invisibility"}
-		(long|extended) invisibility = - {"Potion": "minecraft:long_invisibility"}
-		leaping = - {"Potion": "minecraft:leaping"}
-		(long|extended) leaping = - {"Potion": "minecraft:long_leaping"}
-		(strong|upgraded|level 2) leaping = - {"Potion": "minecraft:strong_leaping"}
-		fire resistance = - {"Potion": "minecraft:fire_resistance"}
-		(long|extended) fire resistance = - {"Potion": "minecraft:long_fire_resistance"}
-		(swiftness|speed) = - {"Potion": "minecraft:swiftness"}
-		(long|extended) (swiftness|speed) = - {"Potion": "minecraft:long_swiftness"}
-		(strong|upgraded|level 2) (swiftness|speed) = - {"Potion": "minecraft:strong_swiftness"}
-		slowness = - {"Potion": "minecraft:slowness"}
-		(long|extended) slowness = - {"Potion": "minecraft:long_slowness"}
-		(strong|upgraded|level 2) slowness = - {"Potion": "minecraft:strong_slowness"}
-		water breathing = - {"Potion": "minecraft:water_breathing"}
-		(long|extended) water breathing = - {"Potion": "minecraft:long_water_breathing"}
-		(healing|instant health) = - {"Potion": "minecraft:healing"}
-		(strong|upgraded|level 2) (healing|instant health) = - {"Potion": "minecraft:strong_healing"}
-		[instant] (harming|damage) = - {"Potion": "minecraft:harming"}
-		(strong|upgraded|level 2) [instant] (harming|damage) = - {"Potion": "minecraft:strong_harming"}
-		poison = - {"Potion": "minecraft:poison"}
-		(long|extended) poison = - {"Potion": "minecraft:long_poison"}
-		(strong|upgraded|level 2) poison = - {"Potion": "minecraft:strong_poison"}
-		regen[eration] = - {"Potion": "minecraft:regeneration"}
-		(long|extended) regen[eration] = - {"Potion": "minecraft:long_regeneration"}
-		(strong|upgraded|level 2) regen[eration] = - {"Potion": "minecraft:strong_regeneration"}
-		strength = - {"Potion": "minecraft:strength"}
-		(long|extended) strength = - {"Potion": "minecraft:long_strength"}
-		(strong|upgraded|level 2) strength = - {"Potion": "minecraft:strong_strength"}
-		weakness = - {"Potion": "minecraft:weakness"}
-		(long|extended) weakness = - {"Potion": "minecraft:long_weakness"}
-		luck = - {"Potion": "minecraft:luck"}
-
 	spectral arrow¦s = minecraft:spectral_arrow[relatedEntity=spectral arrow]
-	{tipped arrow types} tipped arrow¦s = minecraft:tipped_arrow
-	tipped arrow[s] of {tipped arrow types} = minecraft:tipped_arrow
+	{potion types} tipped arrow¦s = minecraft:tipped_arrow
+	tipped arrow[s] of {potion types} = minecraft:tipped_arrow
 
 armor:
 	leather (cap|helmet)¦s = minecraft:leather_helmet
@@ -125,16 +89,6 @@ update aquatic combat items:
 
 	trident¦s = minecraft:trident[relatedEntity=trident]
 
-	{update aquatic effects}:
-		turtle master = - {"Potion": "minecraft:turtle_master"}
-		(long|extended) turtle master = - {"Potion": "minecraft:long_turtle_master"}
-		(strong|upgraded|level 2) turtle master = - {"Potion": "minecraft:strong_turtle_master"}
-		slow fall[ing] = - {"Potion": "minecraft:slow_falling"}
-		(long|extended) slow fall[ing] = - {"Potion": "minecraft:long_slow_falling"}
-
-	{update aquatic effects} tipped arrow¦s = minecraft:tipped_arrow
-	tipped arrow[s] of {update aquatic effects} = minecraft:tipped_arrow
-
 old categories:
 	minecraft version = 1.12.2 or older
 	[any] weapon¦s = any sword, bow
@@ -197,6 +151,8 @@ trails and tales update:
 	spire armo[u]r [trim] smithing template¦s = minecraft:spire_armor_trim_smithing_template
 	[any] [armo[u]r] [trim] smithing template¦s = netherite armor smithing template, sentry armor smithing template, vex armor smithing template, wild armor smithing template, coast armor smithing template, dune armor smithing template, wayfinder armor smithing template, raiser armor smithing template, shaper armor smithing template, host armor smithing template, ward armor smithing template, silence armor smithing template, tide armor smithing template, snout armor smithing template, rib armor smithing template, eye armor smithing template, spire armor smithing template
 
+armor trims before components:
+	minecraft version = 1.20 to 1.20.4
 	{armor trims}:
 		{default} = -
 		(emerald|green) sentry = - {"Trim": {"material": "minecraft:emerald", "pattern": "minecraft:sentry"}}
@@ -374,7 +330,186 @@ trails and tales update:
 		(gold|yellow) spire = - {"Trim": {"material": "minecraft:gold", "pattern": "minecraft:spire"}}
 		(iron|grey|gray) spire = - {"Trim": {"material": "minecraft:iron", "pattern": "minecraft:spire"}}
 		(copper|brown) spire = - {"Trim": {"material": "minecraft:copper", "pattern": "minecraft:spire"}}
+armor trims after components:
+	minecraft version = 1.20.5 or newer
+	{armor trims}:
+		{default} = -
+		(emerald|green) sentry = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:sentry"}}
+		(redstone|red) sentry = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:sentry"}}
+		(lapis [lazuli]|blue) sentry = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:sentry"}}
+		(amethyst [shard]|purple) sentry = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:sentry"}}
+		([nether] quartz|white) sentry = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:sentry"}}
+		(netherite|black) sentry = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:sentry"}}
+		(diamond|light blue) sentry = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:sentry"}}
+		(gold|yellow) sentry = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:sentry"}}
+		(iron|grey|gray) sentry = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:sentry"}}
+		(copper|brown) sentry = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:sentry"}}
 
+		(emerald|green) vex = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:vex"}}
+		(redstone|red) vex = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:vex"}}
+		(lapis [lazuli]|blue) vex = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:vex"}}
+		(amethyst [shard]|purple) vex = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:vex"}}
+		([nether] quartz|white) vex = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:vex"}}
+		(netherite|black) vex = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:vex"}}
+		(diamond|light blue) vex = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:vex"}}
+		(gold|yellow) vex = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:vex"}}
+		(iron|grey|gray) vex = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:vex"}}
+		(copper|brown) vex = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:vex"}}
+
+		(emerald|green) wild = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:wild"}}
+		(redstone|red) wild = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:wild"}}
+		(lapis [lazuli]|blue) wild = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:wild"}}
+		(amethyst [shard]|purple) wild = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:wild"}}
+		([nether] quartz|white) wild = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:wild"}}
+		(netherite|black) wild = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:wild"}}
+		(diamond|light blue) wild = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:wild"}}
+		(gold|yellow) wild = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:wild"}}
+		(iron|grey|gray) wild = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:wild"}}
+		(copper|brown) wild = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:wild"}}
+
+		(emerald|green) coast = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:coast"}}
+		(redstone|red) coast = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:coast"}}
+		(lapis [lazuli]|blue) coast = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:coast"}}
+		(amethyst [shard]|purple) coast = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:coast"}}
+		([nether] quartz|white) coast = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:coast"}}
+		(netherite|black) coast = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:coast"}}
+		(diamond|light blue) coast = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:coast"}}
+		(gold|yellow) coast = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:coast"}}
+		(iron|grey|gray) coast = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:coast"}}
+		(copper|brown) coast = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:coast"}}
+
+		(emerald|green) dune = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:dune"}}
+		(redstone|red) dune = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:dune"}}
+		(lapis [lazuli]|blue) dune = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:dune"}}
+		(amethyst [shard]|purple) dune = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:dune"}}
+		([nether] quartz|white) dune = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:dune"}}
+		(netherite|black) dune = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:dune"}}
+		(diamond|light blue) dune = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:dune"}}
+		(gold|yellow) dune = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:dune"}}
+		(iron|grey|gray) dune = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:dune"}}
+		(copper|brown) dune = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:dune"}}
+
+		(emerald|green) wayfinder = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:wayfinder"}}
+		(redstone|red) wayfinder = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:wayfinder"}}
+		(lapis [lazuli]|blue) wayfinder = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:wayfinder"}}
+		(amethyst [shard]|purple) wayfinder = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:wayfinder"}}
+		([nether] quartz|white) wayfinder = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:wayfinder"}}
+		(netherite|black) wayfinder = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:wayfinder"}}
+		(diamond|light blue) wayfinder = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:wayfinder"}}
+		(gold|yellow) wayfinder = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:wayfinder"}}
+		(iron|grey|gray) wayfinder = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:wayfinder"}}
+		(copper|brown) wayfinder = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:wayfinder"}}
+
+		(emerald|green) raiser = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:raiser"}}
+		(redstone|red) raiser = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:raiser"}}
+		(lapis [lazuli]|blue) raiser = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:raiser"}}
+		(amethyst [shard]|purple) raiser = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:raiser"}}
+		([nether] quartz|white) raiser = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:raiser"}}
+		(netherite|black) raiser = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:raiser"}}
+		(diamond|light blue) raiser = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:raiser"}}
+		(gold|yellow) raiser = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:raiser"}}
+		(iron|grey|gray) raiser = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:raiser"}}
+		(copper|brown) raiser = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:raiser"}}
+
+		(emerald|green) shaper = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:shaper"}}
+		(redstone|red) shaper = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:shaper"}}
+		(lapis [lazuli]|blue) shaper = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:shaper"}}
+		(amethyst [shard]|purple) shaper = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:shaper"}}
+		([nether] quartz|white) shaper = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:shaper"}}
+		(netherite|black) shaper = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:shaper"}}
+		(diamond|light blue) shaper = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:shaper"}}
+		(gold|yellow) shaper = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:shaper"}}
+		(iron|grey|gray) shaper = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:shaper"}}
+		(copper|brown) shaper = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:shaper"}}
+
+		(emerald|green) host = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:host"}}
+		(redstone|red) host = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:host"}}
+		(lapis [lazuli]|blue) host = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:host"}}
+		(amethyst [shard]|purple) host = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:host"}}
+		([nether] quartz|white) host = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:host"}}
+		(netherite|black) host = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:host"}}
+		(diamond|light blue) host = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:host"}}
+		(gold|yellow) host = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:host"}}
+		(iron|grey|gray) host = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:host"}}
+		(copper|brown) host = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:host"}}
+
+		(emerald|green) ward = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:ward"}}
+		(redstone|red) ward = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:ward"}}
+		(lapis [lazuli]|blue) ward = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:ward"}}
+		(amethyst [shard]|purple) ward = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:ward"}}
+		([nether] quartz|white) ward = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:ward"}}
+		(netherite|black) ward = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:ward"}}
+		(diamond|light blue) ward = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:ward"}}
+		(gold|yellow) ward = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:ward"}}
+		(iron|grey|gray) ward = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:ward"}}
+		(copper|brown) ward = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:ward"}}
+
+		(emerald|green) silence = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:silence"}}
+		(redstone|red) silence = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:silence"}}
+		(lapis [lazuli]|blue) silence = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:silence"}}
+		(amethyst [shard]|purple) silence = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:silence"}}
+		([nether] quartz|white) silence = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:silence"}}
+		(netherite|black) silence = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:silence"}}
+		(diamond|light blue) silence = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:silence"}}
+		(gold|yellow) silence = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:silence"}}
+		(iron|grey|gray) silence = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:silence"}}
+		(copper|brown) silence = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:silence"}}
+
+		(emerald|green) tide = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:tide"}}
+		(redstone|red) tide = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:tide"}}
+		(lapis [lazuli]|blue) tide = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:tide"}}
+		(amethyst [shard]|purple) tide = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:tide"}}
+		([nether] quartz|white) tide = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:tide"}}
+		(netherite|black) tide = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:tide"}}
+		(diamond|light blue) tide = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:tide"}}
+		(gold|yellow) tide = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:tide"}}
+		(iron|grey|gray) tide = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:tide"}}
+		(copper|brown) tide = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:tide"}}
+
+		(emerald|green) snout = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:snout"}}
+		(redstone|red) snout = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:snout"}}
+		(lapis [lazuli]|blue) snout = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:snout"}}
+		(amethyst [shard]|purple) snout = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:snout"}}
+		([nether] quartz|white) snout = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:snout"}}
+		(netherite|black) snout = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:snout"}}
+		(diamond|light blue) snout = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:snout"}}
+		(gold|yellow) snout = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:snout"}}
+		(iron|grey|gray) snout = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:snout"}}
+		(copper|brown) snout = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:snout"}}
+
+		(emerald|green) rib = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:rib"}}
+		(redstone|red) rib = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:rib"}}
+		(lapis [lazuli]|blue) rib = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:rib"}}
+		(amethyst [shard]|purple) rib = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:rib"}}
+		([nether] quartz|white) rib = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:rib"}}
+		(netherite|black) rib = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:rib"}}
+		(diamond|light blue) rib = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:rib"}}
+		(gold|yellow) rib = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:rib"}}
+		(iron|grey|gray) rib = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:rib"}}
+		(copper|brown) rib = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:rib"}}
+
+		(emerald|green) eye = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:eye"}}
+		(redstone|red) eye = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:eye"}}
+		(lapis [lazuli]|blue) eye = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:eye"}}
+		(amethyst [shard]|purple) eye = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:eye"}}
+		([nether] quartz|white) eye = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:eye"}}
+		(netherite|black) eye = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:eye"}}
+		(diamond|light blue) eye = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:eye"}}
+		(gold|yellow) eye = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:eye"}}
+		(iron|grey|gray) eye = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:eye"}}
+		(copper|brown) eye = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:eye"}}
+
+		(emerald|green) spire = - {minecraft:trim={"material":"minecraft:emerald","pattern":"minecraft:spire"}}
+		(redstone|red) spire = - {minecraft:trim={"material":"minecraft:redstone","pattern":"minecraft:spire"}}
+		(lapis [lazuli]|blue) spire = - {minecraft:trim={"material":"minecraft:lapis","pattern":"minecraft:spire"}}
+		(amethyst [shard]|purple) spire = - {minecraft:trim={"material":"minecraft:amethyst","pattern":"minecraft:spire"}}
+		([nether] quartz|white) spire = - {minecraft:trim={"material":"minecraft:quartz","pattern":"minecraft:spire"}}
+		(netherite|black) spire = - {minecraft:trim={"material":"minecraft:netherite","pattern":"minecraft:spire"}}
+		(diamond|light blue) spire = - {minecraft:trim={"material":"minecraft:diamond","pattern":"minecraft:spire"}}
+		(gold|yellow) spire = - {minecraft:trim={"material":"minecraft:gold","pattern":"minecraft:spire"}}
+		(iron|grey|gray) spire = - {minecraft:trim={"material":"minecraft:iron","pattern":"minecraft:spire"}}
+		(copper|brown) spire = - {minecraft:trim={"material":"minecraft:copper","pattern":"minecraft:spire"}}
+armor trims:
 	{armor trims} leather (cap|helmet)¦s = minecraft:leather_helmet
 	{armor trims} leather (tunic|chest(piece|plate))¦s = minecraft:leather_chestplate
 	{armor trims} leather (pants|leggings) = minecraft:leather_leggings

--- a/misc.sk
+++ b/misc.sk
@@ -32,7 +32,6 @@ new items:
 	charcoal = minecraft:charcoal
 	sugar cane¦s = minecraft:sugar_cane
 	conduit¦s = minecraft:conduit
-	[turtle [shell]] scute¦s = minecraft:scute
 	kelp = minecraft:kelp
 	nautilus shell¦s = minecraft:nautilus_shell
 	heart[s] of the sea = minecraft:heart_of_the_sea
@@ -51,16 +50,6 @@ new items:
 		(trio of|[pile of] three) = -[eggs=3]
 		[pile of] four = -[eggs=4]
 	{egg count} {hatch stage} turtle egg¦s = minecraft:turtle_egg
-
-valuables:
-	{beacon levels}:
-		{default} = -
-		(level (0|one)|unleveled) = - {Levels:0}
-		(level (1|one)) = - {Levels:1}
-		(level (2|two)) = - {Levels:2}
-		(level (3|three)) = - {Levels:3}
-		(level (4|four)|complete[d]) = - {Levels:4}
-	{beacon levels} beacon¦s = minecraft:beacon
 
 random items:
 	stick¦s = minecraft:stick
@@ -110,12 +99,20 @@ books:
 	enchanted book = minecraft:enchanted_book
 	any book¦s = book, book with text
 
-fireworks:
+fireworks before components:
+	minecraft version = 1.20.4 or older
 	{firework types}:
 		(0|zero|immediate) = - {Fireworks:{Flight:0}}
 		(1|one|short) = - {Fireworks:{Flight:1}}
 		(2|two|medium) = - {Fireworks:{Flight:2}}
 		(3|three|long) = - {Fireworks:{Flight:3}}
+fireworks after components:
+	minecraft version = 1.20.5 or newer
+	{firework types}:
+		(0|zero|immediate) = - {minecraft:fireworks={"flight_duration":0}}
+		(1|one|short) = - {minecraft:fireworks={"flight_duration":1}}
+		(2|two|medium) = - {minecraft:fireworks={"flight_duration":2}}
+		(3|three|long) = - {minecraft:fireworks={"flight_duration":3}}
 
 fireworks before flattening:
 	minecraft version = 1.12.2 or older
@@ -348,20 +345,6 @@ the wild update:
 	# sculk-related stuffs
 	echo shard¦s = minecraft:echo_shard
 	recovery compass¦es = minecraft:recovery_compass
-
-	# Horns
-	{horn variations}:
-		{default} = -
-		ponder = - {"instrument": "minecraft:ponder_goat_horn"}
-		sing = - {"instrument": "minecraft:sing_goat_horn"}
-		seek = - {"instrument": "minecraft:seek_goat_horn"}
-		feel = - {"instrument": "minecraft:feel_goat_horn"}
-		admire = - {"instrument": "minecraft:admire_goat_horn"}
-		call = - {"instrument": "minecraft:call_goat_horn"}
-		yearn = - {"instrument": "minecraft:yearn_goat_horn"}
-		dream = - {"instrument": "minecraft:dream_goat_horn"}
-		
-	{horn variations} goat horn¦s = minecraft:goat_horn
 	
 trails and tales update:
 	minecraft version = 1.20 or newer
@@ -409,3 +392,61 @@ trails and tales update:
 		(stage 4|dusted 3) = -[dusted=3]
 	{dusted} suspicious sand¦s = minecraft:suspicious_sand
 	{dusted} suspicious gravel¦s = minecraft:suspicious_gravel
+
+beacons before components:
+	minecraft version = 1.20.4 or older
+	{beacon levels}:
+		{default} = -
+		(level (0|one)|unleveled) = - {Levels:0}
+		(level (1|one)) = - {Levels:1}
+		(level (2|two)) = - {Levels:2}
+		(level (3|three)) = - {Levels:3}
+		(level (4|four)|complete[d]) = - {Levels:4}
+beacons after components:
+	minecraft version = 1.20.5 or newer
+	{beacon levels}:
+		{default} = -
+		(level (0|one)|unleveled) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":0}}
+		(level (1|one)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":1}}
+		(level (2|two)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":2}}
+		(level (3|three)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":3}}
+		(level (4|four)|complete[d]) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":4}}
+beacons:
+	{beacon levels} beacon¦s = minecraft:beacon
+
+goat horns before components:
+	minecraft version = 1.19 to 1.20.4
+	{horn variations}:
+		{default} = -
+		ponder = - {"instrument": "minecraft:ponder_goat_horn"}
+		sing = - {"instrument": "minecraft:sing_goat_horn"}
+		seek = - {"instrument": "minecraft:seek_goat_horn"}
+		feel = - {"instrument": "minecraft:feel_goat_horn"}
+		admire = - {"instrument": "minecraft:admire_goat_horn"}
+		call = - {"instrument": "minecraft:call_goat_horn"}
+		yearn = - {"instrument": "minecraft:yearn_goat_horn"}
+		dream = - {"instrument": "minecraft:dream_goat_horn"}
+goat horns after components:
+	minecraft version = 1.20.5 or newer
+	{horn variations}:
+		{default} = -
+		ponder = - {minecraft:instrument="minecraft:ponder_goat_horn"}
+		sing = - {minecraft:instrument="minecraft:sing_goat_horn"}
+		seek = - {minecraft:instrument="minecraft:seek_goat_horn"}
+		feel = - {minecraft:instrument="minecraft:feel_goat_horn"}
+		admire = - {minecraft:instrument="minecraft:admire_goat_horn"}
+		call = - {minecraft:instrument="minecraft:call_goat_horn"}
+		yearn = - {minecraft:instrument="minecraft:yearn_goat_horn"}
+		dream = - {minecraft:instrument="minecraft:dream_goat_horn"}
+goat horns:
+	{horn variations} goat horn¦s = minecraft:goat_horn
+
+scutes before 1.20.5:
+	minecraft version = 1.13 to 1.20.4
+
+	[turtle [shell]] scute¦s = minecraft:scute
+
+scutes after 1.20.5:
+	minecraft version = 1.20.5 or newer
+
+	[turtle [shell]] scute¦s = minecraft:turtle_scute

--- a/misc.sk
+++ b/misc.sk
@@ -439,6 +439,7 @@ goat horns after components:
 		yearn = - {minecraft:instrument="minecraft:yearn_goat_horn"}
 		dream = - {minecraft:instrument="minecraft:dream_goat_horn"}
 goat horns:
+	minecraft version = 1.19 or newer
 	{horn variations} goat horn¦s = minecraft:goat_horn
 
 scutes before 1.20.5:

--- a/misc.sk
+++ b/misc.sk
@@ -397,20 +397,20 @@ beacons before components:
 	minecraft version = 1.20.4 or older
 	{beacon levels}:
 		{default} = -
-		(level (0|one)|unleveled) = - {Levels:0}
-		(level (1|one)) = - {Levels:1}
-		(level (2|two)) = - {Levels:2}
-		(level (3|three)) = - {Levels:3}
-		(level (4|four)|complete[d]) = - {Levels:4}
+		(level (0|one)|unleveled) = - {Levels:0} [deduplicate=false]
+		(level (1|one)) = - {Levels:1} [deduplicate=false]
+		(level (2|two)) = - {Levels:2} [deduplicate=false]
+		(level (3|three)) = - {Levels:3} [deduplicate=false]
+		(level (4|four)|complete[d]) = - {Levels:4} [deduplicate=false]
 beacons after components:
 	minecraft version = 1.20.5 or newer
 	{beacon levels}:
 		{default} = -
-		(level (0|one)|unleveled) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":0}}
-		(level (1|one)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":1}}
-		(level (2|two)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":2}}
-		(level (3|three)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":3}}
-		(level (4|four)|complete[d]) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":4}}
+		(level (0|one)|unleveled) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":0}} [deduplicate=false]
+		(level (1|one)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":1}} [deduplicate=false]
+		(level (2|two)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":2}} [deduplicate=false]
+		(level (3|three)) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":3}} [deduplicate=false]
+		(level (4|four)|complete[d]) = - {minecraft:block_entity_data={"id":"minecraft:beacon","Levels":4}} [deduplicate=false]
 beacons:
 	{beacon levels} beacon¦s = minecraft:beacon
 


### PR DESCRIPTION
This PR fixes aliases definitions for 1.20.5 support.

There are some additional improvements made to potion patterns (there should be no breaking changes; these changes are intended to improve the toString output).

### Data Component Support
Since items can no longer be parsed using the old NBT format, this PR updates NBT-using aliases to use the new data component format. As part of these changes, a new `{potion types}` global variation has been added (it is shared between potion bottles and tipped arrows).

### Deduplication Tag

A `deduplication` tag can be appended onto an alias to prevent the deduplication process from taking place. It is similar to the `relatedEntity` tag in that it is internal and removed from the block states map during the parsing process. This is important for items like beacons that have block entity data, which is not associated with any ItemMeta. As a result, if deduplication occurs, a `level one beacon` and `level three beacon` are seen as the same thing (the item metas *appear* to be identical). Thus, we simply opt out of this process for beacons to ensure a `level one beacon` and `level three beacon` actually represent different items (at least when in the inventory!)

For more details, see:
- https://github.com/SkriptLang/Skript/pull/6617