### PR TITLE
Fix pufferfish alias

### DIFF
--- a/foodstuffs.sk
+++ b/foodstuffs.sk
@@ -67,7 +67,7 @@ foods after flattening:
 	cooked cod [fillet]¦s = minecraft:cooked_cod
 	[raw] salmon [fillet]¦s = minecraft:salmon[relatedEntity=salmon]
 	cooked salmon [fillet]¦s = minecraft:cooked_salmon
-	pufferfish¦es = minecraft:pufferfish[relatedEntity=puffer fish]
+	pufferfish¦es = minecraft:pufferfish[relatedEntity=pufferfish]
 	tropical fish¦es = minecraft:tropical_fish[relatedEntity=tropical fish]
 	any raw fish¦es = raw cod, raw salmon, pufferfish, tropical fish
 	


### PR DESCRIPTION
Change 'puffer fish' to 'pufferfish', because that is its actual name.

How it currently is (only the second one works):
![image](https://github.com/user-attachments/assets/e584911c-894a-4dac-9789-8c51d0b73b17)