### PR TITLE
fix: reintroduce brick aliases

### DIFF
--- a/misc.sk
+++ b/misc.sk
@@ -5,6 +5,8 @@ random items:
 	egg¦s = minecraft:egg[relatedEntity=egg]
 	ender pearl¦s = minecraft:ender_pearl[relatedEntity=ender pearl]
 	(bottle[s] o' enchanting|xp bottle¦s|experience bottle¦s) = minecraft:experience_bottle[relatedEntity=xp bottle]
+	brick block¦s = minecraft:bricks
+	brick¦s = minecraft:brick
 
 fireworks before components:
 	minecraft version = 1.20.4 or older


### PR DESCRIPTION
Attempts to fix an issue where removing aliases causes bricks (the block) and bricks (the item) to not be able to be referred to separately.

Was shown this bug in skript-help by DjDisaster, was told that "give player 1 bricks" gives the player brick blocks half the time and brick items the other half.

I am not experienced with aliases, so I'm unsure if this reintroduction of the brick aliases will work.