### PR TITLE
Add Brick / Nether Brick Aliases 

### DIFF
--- a/decoration.sk
+++ b/decoration.sk
@@ -10,3 +10,10 @@ combat update:
 
 caves and cliffs update part 1:
 	glow item frame [item]¦s = minecraft:glow_item_frame[relatedEntity=glow item frame]
+
+# https://github.com/SkriptLang/Skript/issues/7484
+bricks:
+	brick = minecraft:brick
+	bricks = minecraft:bricks
+	nether brick = minecraft:nether_brick
+	nether bricks = minecraft:nether_bricks


### PR DESCRIPTION
Adds brick and nether brick aliases. The existing PR (#122) doesn't include nether bricks and doesn't match the Minecraft IDs

Previous behaviour:
```
brick = doesn't exist
bricks = "bricks banner pattern" - giving it to a player gives a brick block
nether brick = doesn't exist
nether bricks = "nether bricks or nether brick" - giving it to a player gives either item randomly
nether brickss = "nether brick" - item
```

New behaviour:
```
brick = "brick" - item
bricks = "bricks banner pattern" - giving it to a player gives a brick block
nether brick = "nether brick" - item
nether bricks = "nether bricks" - block
nether brickss = doesn't exist
```

This a quick patch, there is a bigger issue that needs to be fixed that will be discussed in a different issue.
With this PR, comparing `type of {_block}` to `bricks` doesn't work and is a known issue. The current workaround is comparing it to `1 bricks`.

Related: [SkriptLang/Skript#7484](https://github.com/SkriptLang/Skript/issues/7484)

